### PR TITLE
ric: read all of thingino.json, and say so when it will not parse

### DIFF
--- a/ric/ric_main.c
+++ b/ric/ric_main.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/epoll.h>
+#include <sys/stat.h>
 
 #include "ric.h"
 
@@ -83,9 +84,34 @@ static void load_config(ric_state_t *st)
  *   "ircut": 57         (single GPIO as integer)
  *   "ir850": 8          (IR LED GPIO)
  *   "ir940": 9          (IR LED GPIO, used if ir850 absent)
+ *
+ * This is one optional discovery source: raptor.conf's [ircut] section is
+ * authoritative and is consulted first, and the file's absence is the normal
+ * case on any image that is not thingino.  So a missing file stays silent --
+ * warning about it on every boot of every OpenIPC camera would be noise.
+ *
+ * A file that exists but cannot be parsed is a different matter and does
+ * warn.  It is a real fault, and from the outside it is indistinguishable
+ * from the file being absent: the pins stay at -1, the >= 0 guards in
+ * ric_daynight.c never fire, and the filter is simply never driven -- no
+ * click, no log line, a magenta daylight cast, and nothing to grep for.
  */
 #define THINGINO_JSON "/etc/thingino.json"
 #define GPIO_PIN_MAX  191
+
+/*
+ * Bound the read explicitly rather than by the size of some buffer.  This
+ * was a fixed 2047-byte fread until 2026-07-28, which silently truncated
+ * mid-structure on any larger file and handed cJSON a malformed document.
+ * That is not a corner case on thingino: nothing there bounds the file and
+ * several packages append to it independently (thingino-core seeds it,
+ * thingino-agent and thingino-ha each import a block), so a stock image is
+ * already over 2047 bytes before a camera-specific key is added -- 2727 on
+ * the board this was found on.  On thingino this path had most likely never
+ * worked; it only looked correct on OpenIPC, where the file is absent and
+ * the early return is the right answer for the wrong reason.
+ */
+#define THINGINO_JSON_MAX (64 * 1024)
 
 static bool valid_gpio(int pin)
 {
@@ -101,19 +127,50 @@ static void load_gpio_from_thingino_json(ric_config_t *c)
 	if (!f)
 		return;
 
-	char buf[2048];
-	size_t n = fread(buf, 1, sizeof(buf) - 1, f);
-	fclose(f);
-	if (n == 0)
+	struct stat sb;
+	if (fstat(fileno(f), &sb) != 0 || !S_ISREG(sb.st_mode)) {
+		RSS_WARN("%s is not a readable regular file -- GPIO discovery skipped",
+			 THINGINO_JSON);
+		fclose(f);
 		return;
-	buf[n] = '\0';
+	}
 
-	cJSON *root = cJSON_Parse(buf);
-	if (!root)
+	if (sb.st_size > THINGINO_JSON_MAX) {
+		RSS_WARN("%s is %lld bytes, over the %d-byte limit -- GPIO discovery skipped",
+			 THINGINO_JSON, (long long)sb.st_size, THINGINO_JSON_MAX);
+		fclose(f);
 		return;
+	}
+
+	char *buf = malloc((size_t)sb.st_size + 1);
+	if (!buf) {
+		RSS_WARN("out of memory reading %s -- GPIO discovery skipped", THINGINO_JSON);
+		fclose(f);
+		return;
+	}
+
+	size_t n = fread(buf, 1, (size_t)sb.st_size, f);
+	fclose(f);
+	buf[n] = '\0';
+	if (n == 0) {
+		free(buf);
+		return;
+	}
+
+	/* cJSON copies what it keeps, so the buffer goes back either way. */
+	cJSON *root = cJSON_Parse(buf);
+	free(buf);
+	if (!root) {
+		RSS_WARN("%s exists but does not parse as JSON -- GPIO discovery skipped, "
+			 "IR-cut and IR LED pins stay unset unless [ircut] provides them",
+			 THINGINO_JSON);
+		return;
+	}
 
 	cJSON *gpio = cJSON_GetObjectItemCaseSensitive(root, "gpio");
 	if (!cJSON_IsObject(gpio)) {
+		/* Parsed fine, just has nothing for us: normal, so debug only. */
+		RSS_DEBUG("%s has no \"gpio\" object -- using [ircut] config only", THINGINO_JSON);
 		cJSON_Delete(root);
 		return;
 	}

--- a/ric/ric_main.c
+++ b/ric/ric_main.c
@@ -85,31 +85,26 @@ static void load_config(ric_state_t *st)
  *   "ir850": 8          (IR LED GPIO)
  *   "ir940": 9          (IR LED GPIO, used if ir850 absent)
  *
- * This is one optional discovery source: raptor.conf's [ircut] section is
- * authoritative and is consulted first, and the file's absence is the normal
- * case on any image that is not thingino.  So a missing file stays silent --
- * warning about it on every boot of every OpenIPC camera would be noise.
+ * One optional discovery source: raptor.conf's [ircut] section is
+ * authoritative and is consulted first, and the file is absent on any image
+ * that is not thingino.  A missing file is therefore normal and stays silent.
  *
- * A file that exists but cannot be parsed is a different matter and does
- * warn.  It is a real fault, and from the outside it is indistinguishable
- * from the file being absent: the pins stay at -1, the >= 0 guards in
- * ric_daynight.c never fire, and the filter is simply never driven -- no
- * click, no log line, a magenta daylight cast, and nothing to grep for.
+ * A file that exists but will not parse does warn.  Failure here is otherwise
+ * invisible -- the pins stay at -1, the >= 0 guards in ric_daynight.c never
+ * fire, and the filter is never driven -- and so is indistinguishable from
+ * the file being absent unless the log says which one happened.  A file that
+ * parses and simply carries no "gpio" object is not a fault, and stays debug.
  */
 #define THINGINO_JSON "/etc/thingino.json"
 #define GPIO_PIN_MAX  191
 
 /*
- * Bound the read explicitly rather than by the size of some buffer.  This
- * was a fixed 2047-byte fread until 2026-07-28, which silently truncated
- * mid-structure on any larger file and handed cJSON a malformed document.
- * That is not a corner case on thingino: nothing there bounds the file and
- * several packages append to it independently (thingino-core seeds it,
- * thingino-agent and thingino-ha each import a block), so a stock image is
- * already over 2047 bytes before a camera-specific key is added -- 2727 on
- * the board this was found on.  On thingino this path had most likely never
- * worked; it only looked correct on OpenIPC, where the file is absent and
- * the early return is the right answer for the wrong reason.
+ * Bound the read explicitly rather than by the size of whatever buffer is at
+ * hand: a short read hands cJSON a document truncated mid-structure, which
+ * surfaces as a parse error and not as a size error.  Nothing bounds this
+ * file -- several thingino packages append to it independently -- so the cap
+ * is what limits how much gets handed to the parser, and no legitimate
+ * config comes close to it.
  */
 #define THINGINO_JSON_MAX (64 * 1024)
 
@@ -149,13 +144,14 @@ static void load_gpio_from_thingino_json(ric_config_t *c)
 		return;
 	}
 
+	/*
+	 * A short read is not special-cased: an empty or partial file is a fault
+	 * of the same kind as a malformed one, and letting it reach cJSON_Parse
+	 * means it reports through the same warning instead of returning silently.
+	 */
 	size_t n = fread(buf, 1, (size_t)sb.st_size, f);
 	fclose(f);
 	buf[n] = '\0';
-	if (n == 0) {
-		free(buf);
-		return;
-	}
 
 	/* cJSON copies what it keeps, so the buffer goes back either way. */
 	cJSON *root = cJSON_Parse(buf);


### PR DESCRIPTION
### The symptom

The IR-cut filter never engages: no audible click on a day/night switch, and a
magenta cast on the daylight stream from unfiltered IR reaching the sensor.
Nothing in any log explains it — `logread` is clean on the subject.

### The cause

`load_gpio_from_thingino_json()` in `ric/ric_main.c` reads a fixed 2047 bytes of
a file that has no size bound:

```c
char buf[2048];
size_t n = fread(buf, 1, sizeof(buf) - 1, f);
```

On anything larger, `fread` stops mid-structure, `cJSON_Parse` gets a malformed
document and returns NULL, and the function returns **silently**. `gpio_ircut`
stays `-1`, the `>= 0` guards in `ric_daynight.c:176` never fire,
`gpio_export`/`gpio_set` are never called, and the filter is never driven.

Note the key position is irrelevant — the parse fails on the whole document, so
a `"gpio"` key well inside the first 2047 bytes does not survive.

### Why this is not niche

Nothing in thingino bounds `/etc/thingino.json`, and several packages append to
it independently (`thingino-core` seeds it, `thingino-agent` and `thingino-ha`
each `jct import` a block, and the camera's own file is merged in). The `ha`
block alone is ~700 bytes. A stock thingino image is already over 2047 bytes
before any camera-specific key — 2727 on the board this was found on. So on
thingino this path has most likely **never worked**. It only looks correct on
OpenIPC, where the file is absent and the early return is the right answer for
the wrong reason.

```
$ stat -c%s /etc/thingino.json
2727
$ head -c 2047 /etc/thingino.json | python3 -c 'import json,sys; json.loads(sys.stdin.read())'
json.decoder.JSONDecodeError: Expecting value: line 64 column 15 (char 2047)
```

### The change

Size the read from `fstat`, bound it explicitly at 64KB, and warn when that
bound is hit rather than silently truncating at whatever a buffer happens to
hold.

The silence is the other half of the bug, so the exits are split by whether they
describe a fault. The existing comment's reasoning — that warning on every boot
of every OpenIPC camera would be noise — is right for a *missing* file, and that
case stays silent. It does not hold for a parse failure of a file that exists:
that is a real fault and is indistinguishable from the outside from the file
being absent. A file that parses but has no `"gpio"` object stays debug.

- `fopen` fails → silent (normal off thingino)
- exists but does not parse → **`RSS_WARN`**, naming the file
- parses, no `gpio` object → `RSS_DEBUG`

That middle case is what cost the debugging time here; a one-line warning would
have made it a five-minute fix instead of a bisect through the ISP.

### Verification

Against a synthesised 2727-byte `thingino.json`, with the old and new read paths
compiled side by side against this repo's own cJSON and run under ASan+UBSan:

| file | old | new |
|---|---|---|
| 2727-byte thingino.json | parse fails, no pin | pin 24 |
| small OpenIPC-shaped file | pin 24 | pin 24 |
| empty file | silent return | silent return |
| 70KB file | parse fails silently | refused, warned |
| directory | fails mute | warned |

`"gpio"` sits at byte 35 in that test file — far inside the old buffer — and the
old path still fails, confirming the whole-document point above.

Builds clean for ARM and passes `-Wall -Wextra` with no new warnings.

### Credit

Found and diagnosed from a thingino-on-SigmaStar (SSC30KQ) port. The bug is in
`ric` and is not SigmaStar-specific — it affects every thingino camera whose
`/etc/thingino.json` exceeds 2047 bytes.
