### PR TITLE
ric: reject incomplete Thingino JSON reads

### DIFF
--- a/ric/ric_json.c
+++ b/ric/ric_json.c
@@ -79,13 +79,17 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 	}
 
 	/*
-	 * A short read is not special-cased: an empty or partial file is
-	 * a fault of the same kind as a malformed one, and letting it
-	 * reach cJSON_Parse means it reports through the same warning
-	 * instead of returning silently.
+	 * Parse only a complete snapshot of the regular file; accepting a
+	 * short read could silently discard configuration near the end.
 	 */
 	size_t n = fread(buf, 1, (size_t)sb.st_size, f);
 	fclose(f);
+	if (n != (size_t)sb.st_size) {
+		RSS_WARN("short read from %s -- GPIO discovery skipped", path);
+		free(buf);
+		return;
+	}
+
 	buf[n] = '\0';
 
 	/* cJSON copies what it keeps, so the buffer goes back either way. */


### PR DESCRIPTION
## Summary

- require `fread()` to return the complete size reported by `fstat()`
- skip GPIO discovery with a targeted warning when the configuration snapshot is incomplete
- free the read buffer on the new error path

## Rationale

Passing a short read to cJSON can make a truncated document look like ordinary malformed JSON or, if truncation happens at a valid boundary, accept only part of a concurrently changed configuration. GPIO discovery should only consume the complete regular-file snapshot it sized before reading.

## Validation

- `git diff --check`
- patch applies to current `main` (`717d824`)

The downstream Thingino firmware build will provide the target T40/uClibc integration test.