### PR TITLE
rvd: do not request IDRs on JPEG channels

### DIFF
--- a/rvd/rvd_frame_loop.c
+++ b/rvd/rvd_frame_loop.c
@@ -146,8 +146,16 @@ void *rvd_encoder_thread(void *arg)
 			}
 		}
 
-		/* Check for consumer IDR request (set via ring header flag) */
-		if (s->ring && rss_ring_check_idr(s->ring))
+		/*
+		 * Check for consumer IDR request (set via ring header flag).
+		 *
+		 * Not for JPEG: every MJPEG frame is already intra, so there is
+		 * no such thing as a keyframe request on that channel. A
+		 * consumer that skipped or overflowed sets the flag on whatever
+		 * ring it reads without knowing the codec, so the filtering has
+		 * to happen here.
+		 */
+		if (s->ring && rss_ring_check_idr(s->ring) && !s->is_jpeg)
 			RSS_HAL_CALL(st->ops, enc_request_idr, st->hal_ctx, s->chn);
 
 		/* Block until encoder has a frame (up to 1 second timeout).


### PR DESCRIPTION
Every MJPEG frame is already intra, so a keyframe request on a JPEG channel is meaningless — there is no non-intra frame for it to skip ahead from — and an encoder is entitled to reject it. On SigmaStar MI does exactly that, with `MI_ERR_VENC_CHN_NOT_STARTED`.

`rsd` raises the ring's IDR flag from its skip, `EOVERFLOW` and sendq-full paths without knowing the codec of the ring it is reading, so a JPEG consumer that falls behind asks for a keyframe like any other. The filtering belongs on this side, where the codec is known.

---

### Scope reduced since first posted
This PR originally also checked `enc_start`'s discarded return value and retried on failure. That half has been withdrawn, for two reasons:

1. **It was diagnostics, not a fix.** It made a real defect visible — a failed `enc_start` still set `s->enabled = true`, leaving rvd's view and the encoder's disagreeing — but it did not explain or fix the underlying failure, which has still never been printed.
2. **The retry it added would flood the log.** The `continue` re-enters `while (rss_running(...))`, so a persistently failing `enc_start` would warn every 100ms — 10 lines a second, indefinitely, for as long as a consumer holds the ring.

The `enc_start` state-consistency issue is real and worth fixing on its own terms, with a latched warning rather than a per-iteration one. It will come back as its own change once the underlying failure is understood rather than merely reported.

Part of a short series that supersedes the RFC in #9.
