### PR TITLE
ric: stop reading a missing light reading as darkness

### DIFF
--- a/ric/ric.h
+++ b/ric/ric.h
@@ -176,6 +176,10 @@ typedef struct {
 	/* ADC state */
 	bool adc_initialized;
 
+	/* One-shot diagnostics: a missing signal is worth saying once, and
+	 * saying every poll instead is how a log stops being read. */
+	bool no_exposure_warned;
+
 	/* Control */
 	rss_ctrl_t *ctrl;
 	rss_config_t *cfg;

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -72,7 +72,7 @@ void ric_adc_cleanup(ric_state_t *st)
 	st->adc_initialized = false;
 }
 
-static void gpio_export(int pin)
+static void gpio_export(int pin, const char *direction)
 {
 	if (pin < 0)
 		return;
@@ -94,8 +94,8 @@ static void gpio_export(int pin)
 
 	int fd = open(path, O_WRONLY);
 	if (fd >= 0) {
-		if (write(fd, "out", 3) < 0)
-			RSS_WARN("gpio %d direction: %s", pin, strerror(errno));
+		if (write(fd, direction, strlen(direction)) < 0)
+			RSS_WARN("gpio %d direction %s: %s", pin, direction, strerror(errno));
 		close(fd);
 	}
 }
@@ -116,13 +116,13 @@ static void gpio_set(int pin, int value)
 
 void ric_gpio_init(ric_state_t *st)
 {
-	gpio_export(st->settings.gpio_ircut);
+	gpio_export(st->settings.gpio_ircut, "out");
 	if (st->settings.gpio_ircut2 >= 0)
-		gpio_export(st->settings.gpio_ircut2);
+		gpio_export(st->settings.gpio_ircut2, "out");
 	if (st->settings.gpio_irled >= 0)
-		gpio_export(st->settings.gpio_irled);
+		gpio_export(st->settings.gpio_irled, "out");
 	if (st->settings.gpio_irled2 >= 0)
-		gpio_export(st->settings.gpio_irled2);
+		gpio_export(st->settings.gpio_irled2, "out");
 }
 
 /*
@@ -214,6 +214,40 @@ void ric_set_mode(ric_state_t *st, ric_mode_t mode)
 }
 
 /*
+ * Debounce, shared by every trigger: hysteresis_sec consecutive polls
+ * agreeing before the filter moves. `why` is the trigger's own account of
+ * the decision, since the numbers that justify it differ per trigger.
+ */
+static void ric_debounce(ric_state_t *st, bool want_night, bool want_day, const char *why)
+{
+	if (st->current_mode == RIC_MODE_DAY) {
+		if (want_night) {
+			st->night_count++;
+			st->day_count = 0;
+			if (st->night_count >= st->settings.hysteresis_sec) {
+				RSS_DEBUG("night detected (%s for %ds)", why,
+					  st->settings.hysteresis_sec);
+				ric_set_mode(st, RIC_MODE_NIGHT);
+			}
+		} else {
+			st->night_count = 0;
+		}
+	} else {
+		if (want_day) {
+			st->day_count++;
+			st->night_count = 0;
+			if (st->day_count >= st->settings.hysteresis_sec) {
+				RSS_DEBUG("day detected (%s for %ds)", why,
+					  st->settings.hysteresis_sec);
+				ric_set_mode(st, RIC_MODE_DAY);
+			}
+		} else {
+			st->day_count = 0;
+		}
+	}
+}
+
+/*
  * Poll ISP exposure and decide day/night transition.
  * Uses total_gain with hysteresis debounce.
  */
@@ -253,10 +287,40 @@ void ric_poll_exposure(ric_state_t *st)
 	wb_bgain = (uint16_t)json_get_uint(parsed, "wb_bgain");
 	cJSON_Delete(parsed);
 
+	/*
+	 * Zero means "this backend cannot answer for that field" -- the
+	 * exposure contract raptor-hal documents in hal_isp.c, not a
+	 * convention invented here. A live sensor never reports a mean luma
+	 * of exactly 0, so treating it as absent costs nothing real.
+	 */
+	bool have_gain = total_gain > 0;
+	bool have_luma = ae_luma > 0;
+	bool have_ev = ev > 0;
+
+	if (!have_gain && !have_luma && !have_ev) {
+		if (!st->no_exposure_warned) {
+			RSS_WARN("no exposure data from rvd (gain, luma and ev all zero) -- "
+				 "holding %s mode. This platform's HAL has no exposure "
+				 "readback; use `raptorctl ric mode day|night`, or "
+				 "trigger=adc if the board has a photoresistor",
+				 st->current_mode == RIC_MODE_NIGHT ? "night" : "day");
+			st->no_exposure_warned = true;
+		}
+		return;
+	}
+
 	/* Photo mode has its own state machine — bypass cooldown/hysteresis */
 	if (st->settings.trigger == RIC_TRIGGER_PHOTO) {
-		ric_photo_poll(st, ev, wb_rgain, wb_bgain);
-		return;
+		if (have_ev) {
+			ric_photo_poll(st, ev, wb_rgain, wb_bgain);
+			return;
+		}
+		/* Every phase of the photo state machine compares against ev,
+		 * so with no ev there is nothing to run. Changing the trigger
+		 * is what keeps this to one line. */
+		RSS_WARN("photo trigger needs ev, which this platform does not report -- "
+			 "falling back to the luma trigger");
+		st->settings.trigger = RIC_TRIGGER_LUMA;
 	}
 
 	/* Cooldown after mode switch: wait for IR LEDs / ISP to stabilize.
@@ -272,7 +336,8 @@ void ric_poll_exposure(ric_state_t *st)
 		return;
 	}
 
-	bool want_night, want_day;
+	bool want_night = false, want_day = false;
+	char why[128];
 
 	if (st->settings.trigger == RIC_TRIGGER_LUMA) {
 		/*
@@ -289,17 +354,30 @@ void ric_poll_exposure(ric_state_t *st)
 		 *   we compare against the same sensor's own night baseline.
 		 *   ae_luma is NOT used here because IR illumination inflates
 		 *   it regardless of ambient light level.
+		 *
+		 * Each term is gated on its field being reported, so a
+		 * platform missing one runs on the other alone.
 		 */
-		want_night = (ae_luma < (uint32_t)st->settings.night_luma) ||
-			     (total_gain > (uint32_t)st->settings.night_gain);
+		want_night = (have_luma && ae_luma < (uint32_t)st->settings.night_luma) ||
+			     (have_gain && total_gain > (uint32_t)st->settings.night_gain);
 
-		if (st->night_gain_baseline > 0) {
+		if (have_gain && st->night_gain_baseline > 0) {
 			uint32_t day_thr =
 				st->night_gain_baseline * (uint32_t)st->settings.day_gain_pct / 100;
 			want_day = (total_gain < day_thr);
+		} else if (!have_gain) {
+			/* No gain means no baseline and so no ratio; the
+			 * inverse of the day→night test is all that is left.
+			 * Weaker, since IR illumination lifts luma too, but
+			 * never leaving night is the worse failure. */
+			want_day = have_luma && ae_luma >= (uint32_t)st->settings.night_luma;
 		} else {
 			want_day = false;
 		}
+
+		snprintf(why, sizeof(why), "luma=%u/%d gain=%u/%d night baseline=%u x %d%%",
+			 ae_luma, st->settings.night_luma, total_gain, st->settings.night_gain,
+			 st->night_gain_baseline, st->settings.day_gain_pct);
 	} else if (st->settings.trigger == RIC_TRIGGER_ADC) {
 		/*
 		 * ADC mode: read photoresistor via SU_ADC.
@@ -314,38 +392,15 @@ void ric_poll_exposure(ric_state_t *st)
 		}
 		want_night = (adc_val < st->settings.adc_night);
 		want_day = (adc_val > st->settings.adc_day);
+		snprintf(why, sizeof(why), "adc=%d, night<%d day>%d", adc_val,
+			 st->settings.adc_night, st->settings.adc_day);
 	} else {
 		/* Gain mode (legacy): fixed thresholds, sensor-dependent. */
-		want_night = (total_gain > (uint32_t)st->settings.night_threshold);
-		want_day = (total_gain < (uint32_t)st->settings.day_threshold);
+		want_night = have_gain && total_gain > (uint32_t)st->settings.night_threshold;
+		want_day = have_gain && total_gain < (uint32_t)st->settings.day_threshold;
+		snprintf(why, sizeof(why), "gain=%u, night>%d day<%d", total_gain,
+			 st->settings.night_threshold, st->settings.day_threshold);
 	}
 
-	if (st->current_mode == RIC_MODE_DAY) {
-		if (want_night) {
-			st->night_count++;
-			st->day_count = 0;
-			if (st->night_count >= st->settings.hysteresis_sec) {
-				RSS_DEBUG("night detected (luma=%u gain=%u for %ds)", ae_luma,
-					  total_gain, st->settings.hysteresis_sec);
-				ric_set_mode(st, RIC_MODE_NIGHT);
-			}
-		} else {
-			st->night_count = 0;
-		}
-	} else {
-		if (want_day) {
-			st->day_count++;
-			st->night_count = 0;
-			if (st->day_count >= st->settings.hysteresis_sec) {
-				uint32_t day_thr = st->night_gain_baseline *
-						   (uint32_t)st->settings.day_gain_pct / 100;
-				RSS_DEBUG("day detected (gain=%u < %u [%d%% of %u] for %ds)",
-					  total_gain, day_thr, st->settings.day_gain_pct,
-					  st->night_gain_baseline, st->settings.hysteresis_sec);
-				ric_set_mode(st, RIC_MODE_DAY);
-			}
-		} else {
-			st->day_count = 0;
-		}
-	}
+	ric_debounce(st, want_night, want_day, why);
 }


### PR DESCRIPTION
`ric`'s day→night test is `ae_luma < night_luma`, and rvd answers `get-exposure` from a zeroed struct when the platform's HAL has no `isp_get_exposure` — so `0 < 20`, on every poll, forever. **Any backend without an exposure readback pins the camera in night mode the moment auto mode is enabled.**

Zero as "not reported" is not a convention invented here: it is the exposure contract raptor-hal documents in `hal_isp.c`, and the Ingenic backend already relies on it — when `GetAeStatistics` fails it warns once and leaves `ae_luma` at 0 so that "day/night falls back to gain-only behavior". `ric` implemented that fallback on no platform. It does now.

Each term is gated on its field being reported, and exposure that is entirely zero warns once and holds the current mode rather than acting on silence.

**The full reasoning — both fallback consequences, and why the debounce refactor is in the same change — is in the commit message** rather than repeated here or carried as comment blocks in the source.

Found while bringing up a new HAL backend, but the defect predates it and affects any platform whose HAL lacks the readback.

---
Part of a short series that supersedes the RFC in #9; each part stands alone.
