### PR TITLE
build: build the sibling libraries through their own sub-makes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,18 +223,56 @@ phase1: libs rvd ringdump raptorctl
 
 libs: $(LIB_HAL_VIDEO_FILE) $(LIB_HAL_AUDIO_FILE) $(LIB_IPC_FILE) $(LIB_COMMON_FILE)
 
-$(LIB_HAL_VIDEO_FILE) $(LIB_HAL_AUDIO_FILE):
+# The sibling libraries are built by sub-makes, reached through a phony
+# target rather than by a rule on the library files themselves.
+#
+# A rule whose target is the library and which carries no prerequisites runs
+# only when the file is missing, so edits to a sibling's sources never reach
+# the daemons here. Only the sub-make knows what its own library depends on,
+# and a phony prerequisite is what hands it that decision on every build.
+#
+# One phony target per sibling, not one per library file: make enters a phony
+# target once per run however many targets depend on it, so the raptor-hal
+# sub-make cannot run twice concurrently under -j for its two archives.
+#
+# Each block is guarded on its sibling being present, because these rules
+# describe a developer checkout, where raptor-hal, raptor-ipc and raptor-common
+# sit next to this tree. A packaged build has no siblings -- each library comes
+# from its own package through LIB_*_FILE pointing into the sysroot, where the
+# file already exists and nothing here should try to enter a directory that is
+# not there. Guarded per library rather than once for all three, because a
+# mixture is legal: bisecting one library while the other two come from
+# staging.
+ifneq ($(wildcard $(HAL_DIR)/Makefile),)
+.PHONY: build-raptor-hal
+build-raptor-hal:
 	@echo "  BUILD   raptor-hal"
 	$(Q)$(MAKE) -C $(HAL_DIR) PLATFORM=$(PLATFORM) CROSS_COMPILE=$(CROSS_COMPILE) \
 		$(if $(DEBUG),DEBUG=1,)
 
-$(LIB_IPC_FILE):
+$(LIB_HAL_VIDEO_FILE) $(LIB_HAL_AUDIO_FILE): build-raptor-hal
+	@:
+endif
+
+ifneq ($(wildcard $(IPC_DIR)/Makefile),)
+.PHONY: build-raptor-ipc
+build-raptor-ipc:
 	@echo "  BUILD   raptor-ipc"
 	$(Q)$(MAKE) -C $(IPC_DIR) CC="$(CC)"
 
-$(LIB_COMMON_FILE):
+$(LIB_IPC_FILE): build-raptor-ipc
+	@:
+endif
+
+ifneq ($(wildcard $(COMMON_DIR)/Makefile),)
+.PHONY: build-raptor-common
+build-raptor-common:
 	@echo "  BUILD   raptor-common"
 	$(Q)$(MAKE) -C $(COMMON_DIR) CC="$(CC)"
+
+$(LIB_COMMON_FILE): build-raptor-common
+	@:
+endif
 
 # -- Daemons --
 


### PR DESCRIPTION
Two defects in the sibling-library rules, both reproducible on `main`.

**1. Sibling edits never reach the daemons.** The three rules carry no
prerequisites at all, so once an archive exists make considers it finished and
never looks at the sources again. Append a function to
`raptor-common/src/rss_log.c` and rebuild rsd: the archive's timestamp does not
move, the sub-make is never entered, and the symbol is absent from
`librss_common.a`. The build reports success while linking code that is not the
code in the checkout.

**2. The HAL sub-make runs twice, concurrently, under `-j`.**
`$(LIB_HAL_VIDEO_FILE) $(LIB_HAL_AUDIO_FILE):` is two independent rules sharing
one recipe as far as make is concerned. `make -j16 libs` on a clean tree enters
the raptor-hal sub-make twice at once, over the same object files.

### Fix

Each sibling gets a phony target that its libraries depend on. The sub-make
decides what is out of date, which is the only place that knowledge exists, and
make enters a phony target once per run however many targets depend on it — so
the two HAL archives can no longer start two sub-makes.

### Why not a stamp file

A stamp has to be kept in step with the libraries it stands for. Delete an
archive and leave the stamp, and make believes the rule already produced the
file, the sub-make never runs, and the link dies on a missing `-l`. Every path
that removes a library then has to remove the stamp too — here, in each
sibling's own `clean`, and in packaging — and it puts a build artifact into
raptor-ipc and raptor-common that their `.gitignore` and `clean` rules would
have to learn about. Deferring to the sub-make needs none of that, and keeps the
property this tree has today: a deleted archive is simply rebuilt.

This supersedes the earlier stamp-based version of this PR. The two companion
PRs that went with it (raptor-ipc#1, raptor-common#3) existed only to teach
`clean` about `.built`, and are no longer needed.

### Guards

Each block is guarded on the sibling's `Makefile` existing. A Buildroot build
has no siblings — each library is built by its own package and handed to this
one through `LIB_*_FILE` pointing into the sysroot. Unguarded, make would try to
enter a directory that is not there.

### Tested

Ingenic T31, mipsel uclibc gcc 15.3, siblings at upstream `main`:

| check | `main` | this PR |
|---|---|---|
| a sibling source edit reaches the daemon | no | **yes** |
| raptor-hal sub-makes under `-j16` | 2, concurrent | **1** |
| deleted archive is rebuilt, not fatal | yes | **yes** |
| no-op rebuild does not relink daemons | yes | **yes** |
| staged libraries, siblings absent | n/a | **no rule claims them** |
| full build (rvd rsd ric rhd rmr rmd rwc) | builds | **builds** |

The stamp-based version of this change fails the third row; that is what
prompted the rewrite.
