### PR TITLE
rsd: use the IPv4-capable listen socket helper

### DIFF
--- a/rsd/rsd_server.c
+++ b/rsd/rsd_server.c
@@ -427,29 +427,28 @@ int rsd_server_init(rsd_server_t *srv)
 		}
 	}
 
-	/* Create dual-stack IPv6 listen socket */
-	srv->listen_fd = socket(AF_INET6, SOCK_STREAM, 0);
+	/* Listen socket: dual-stack IPv6 where the kernel has IPv6, IPv4-only
+	 * where it does not. The stages stay open-coded rather than calling
+	 * rss_listen_tcp() so a failure still says which step failed — bind
+	 * losing to EADDRINUSE is the common one and worth naming. */
+	int family = AF_INET6;
+	srv->listen_fd = rss_socket_tcp(&family);
 	if (srv->listen_fd < 0) {
 		RSS_FATAL("socket failed: %s", strerror(errno));
 		return -1;
 	}
+	if (family == AF_INET)
+		RSS_INFO("kernel has no IPv6; listening on IPv4 only");
 
 	int one = 1;
 	setsockopt(srv->listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
 
-	/* Dual-stack: accept both IPv4 and IPv6 */
-	int zero = 0;
-	setsockopt(srv->listen_fd, IPPROTO_IPV6, IPV6_V6ONLY, &zero, sizeof(zero));
-
 	rss_set_nonblocking(srv->listen_fd);
 
-	struct sockaddr_in6 addr = {
-		.sin6_family = AF_INET6,
-		.sin6_port = htons(srv->port),
-		.sin6_addr = in6addr_any,
-	};
+	struct sockaddr_storage addr;
+	socklen_t addrlen = rss_sockaddr_any(family, (uint16_t)srv->port, &addr);
 
-	if (bind(srv->listen_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+	if (bind(srv->listen_fd, (struct sockaddr *)&addr, addrlen) < 0) {
 		RSS_FATAL("bind port %d failed: %s", srv->port, strerror(errno));
 		close(srv->listen_fd);
 		return -1;


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on gtxaspec/raptor-common#2 — do not merge or build this first.**
> It calls `rss_socket_tcp()` and `rss_sockaddr_any()`, which that PR adds to
> `include/rss_net.h`. Against `raptor-common` main today both are implicit
> declarations, and since this tree builds with `-Werror` that is a hard
> compile error, not a warning.

rsd open-codes the dual-stack `AF_INET6` listen socket instead of calling `rss_listen_tcp`, so it does not benefit from that helper's IPv4 fallback and dies at startup on an IPv6-less kernel with:

```
socket failed: Address family not supported by protocol
```

Observed on a board whose kernel is built without IPv6 — it has no `/proc/net/if_inet6` at all, and `AF_INET6` is refused outright with `EAFNOSUPPORT`. OpenIPC ships IPv6-less kernels on the smaller SoCs, so this is not an exotic configuration.

This switches to `rss_socket_tcp` + `rss_sockaddr_any`, and logs once when the fallback engages so an IPv4-only listener is visible rather than inferred. The stages stay open-coded rather than collapsing into `rss_listen_tcp`, because rsd reports which one failed and naming bind's `EADDRINUSE` separately is worth keeping.

Nothing else in rsd assumed v6: `accept_client` already used `sockaddr_storage` with the family-agnostic `rss_addr_str`/`rss_addr_port`, the RTP/RTCP sockets take their family from the client address, and the SDP is IP4 throughout.

The alternative — open-coding the fallback here instead — was rejected: the family decision belongs in the shared header where `rhd` picks it up too, rather than being duplicated per daemon.

---
Part of a short series that supersedes the RFC in #9.

