### PR TITLE
ric: seed the photo day-approach reference so that path can fire

### DIFF
--- a/ric/ric_photo.c
+++ b/ric/ric_photo.c
@@ -257,12 +257,26 @@ static void photo_day_control(ric_state_t *st)
 
 	uint32_t sample = ps->day_ring[(idx - 1) % PHOTO_DAY_RING_SIZE];
 	double s = (double)sample;
-	double ref = (double)ps->day_ref_ev;
 
-	if (ref <= 0.0) {
-		ps->day_ring_idx = 0;
+	/*
+	 * The first full ring seeds the reference, the same way the
+	 * interference and fixed-EV detectors seed theirs: adopt the newest
+	 * sample only once the ring's ends agree, so the value stood still
+	 * rather than being caught mid-swing. Nothing below can run until
+	 * there is a reference to measure against.
+	 */
+	if (ps->day_ref_ev == 0) {
+		double first = (double)ps->day_ring[0];
+
+		if (s < first * FIXED_RATIO_LOW || s > first * FIXED_RATIO_HIGH) {
+			ps->day_ring_idx = 0;
+			return;
+		}
+		ps->day_ref_ev = sample;
 		return;
 	}
+
+	double ref = (double)ps->day_ref_ev;
 
 	/*
 	 * Ratio check — inverted because LOW ev = bright.

--- a/tests/ric_harness.py
+++ b/tests/ric_harness.py
@@ -719,8 +719,9 @@ def scenario_gain_trigger(stub, watch):
 def scenario_photo(stub, watch):
     """Photo trigger: AWB auto-calibration from bright samples, night via
     EV + R-gain spectral shift (path 1), day via the fixed-EV drift
-    detector. (The day-approach ratio path cannot fire: day_ref_ev is
-    never assigned anywhere in ric_photo.c.)"""
+    detector. The day-approach ratio path is the other way into day and
+    has its own scenario below; here ev stays above photo_ev_day, so the
+    ratio path's ring never accumulates and drift is the only route."""
     conf = GPIO_CONF + "trigger = photo\n"
     stub.set_scene(luma=100, gain=500, ev=3000, rgain=140, bgain=140)
     ric = Ric("photo", conf, poll_ms=100)
@@ -749,6 +750,48 @@ def scenario_photo(stub, watch):
     stub.set_scene(luma=60, gain=2000, ev=30000, rgain=150, bgain=140)
     ok = wait_for(lambda: "day" in stub.modes_since(mm), 8)
     result(ok, "photo: day via fixed-EV drift", str(stub.modes_since(mm)))
+    ric.stop()
+
+
+def scenario_photo_day_ratio(stub, watch):
+    """The day-approach ratio path must be able to fire at all.
+
+    day_ref_ev was declared and read but never assigned, so ref was
+    always 0, the `ref <= 0` early return ran on every poll, and
+    everything below it -- including its ric_set_mode(DAY) -- was dead.
+    Day recovery came only from the fixed-EV drift detector, which is a
+    separate path running in this same phase and would mask the defect
+    in a mode-only assertion. So assert on the ratio path's own log
+    line rather than on the mode.
+
+    photo_ev_day is raised so the ring can accumulate on a step down
+    small enough not to hand the win to the drift detector."""
+    conf = (GPIO_CONF + "trigger = photo\nphoto_ev_day = 90000\n"
+            + "hysteresis_sec = 0\n")
+    stub.set_scene(luma=100, gain=500, ev=3000, rgain=140, bgain=140)
+    ric = Ric("photodayratio", conf, poll_ms=100)
+    if not ric.wait_running():
+        result(False, "photo-day-ratio: ric start", "no 'ric running'")
+        ric.stop()
+        return
+    if not wait_for(lambda: "photo AWB calibrated" in ric.read_log(), 6):
+        result(False, "photo-day-ratio: AWB calibration", ric.read_log()[-300:])
+        ric.stop()
+        return
+
+    mm = stub.mark()
+    stub.set_scene(luma=10, gain=20000, ev=100000, rgain=170, bgain=140)
+    if not wait_for(lambda: "night" in stub.modes_since(mm), 10):
+        result(False, "photo-day-ratio: reaches night", str(stub.modes_since(mm)))
+        ric.stop()
+        return
+
+    # Brighten to just under photo_ev_day and hold it there.
+    stub.set_scene(luma=60, gain=2000, ev=85000, rgain=150, bgain=140)
+    ok = wait_for(lambda: "photo day approach" in ric.read_log()
+                  or "photo day trigger" in ric.read_log(), 15)
+    result(ok, "photo: the day-approach ratio path can fire",
+           ric.read_log()[-400:])
     ric.stop()
 
 
@@ -964,6 +1007,7 @@ def main():
         scenario_startup_forced,
         scenario_gain_trigger,
         scenario_photo,
+        scenario_photo_day_ratio,
         scenario_photo_no_ev,
         scenario_zero_exposure,
         scenario_partial_fields,


### PR DESCRIPTION
Picking up the `day_ref_ev` finding from the #14 review.

`day_ref_ev` is declared in `ric.h` and read three times in `ric_photo.c`, but
never assigned anywhere in the tree. `ric_photo_reset()` memsets the state and
restores only the calibration fields, so it stays zero for the life of the
process. `ref` is therefore always 0, the `ref <= 0.0` early return runs on
every poll, and everything below it is unreachable — the ratio band, the
three-strike `day_trigger_count`, and its `ric_set_mode(RIC_MODE_DAY)`.

What kept this invisible: the fixed-EV drift detector runs in the same phase and
reaches day by a different route, so the daemon still recovers and nothing looks
broken from outside.

### The fix

Seed it the way the two sibling detectors in this same file already seed theirs.
`interf_ref_ev` and `fixed_ref_ev` each wait for a full ring, check the ring's
ends agree within `FIXED_RATIO_LOW/HIGH` so the value stood still rather than
being caught mid-swing, then adopt the newest sample — and their `== 0` test on
later polls means "not seeded yet". The day path had the ring, the fullness gate
and the zero test, but no seeding branch, so its zero test meant "give up"
instead. Because that branch also reset `day_ring_idx`, the ring never
accumulated either.

**Interpretation worth a second opinion:** I read the reference as belonging to
the phase rather than to the day/night cycle, on the grounds that `day_ref_ev`
is deliberately absent from the list `ric_photo_reset()` preserves while the
calibration fields are in it. If it was instead meant to be a remembered
daylight EV surviving the phase change, the fix is a different one and I'll
redo it.

### Test

`scenario_photo_day_ratio` in the ric harness. It asserts on the ratio path's
own log line rather than on the resulting mode, because the drift detector
reaches day too — a mode-only assertion passes on the unfixed code. Verified
both ways: the scenario **fails on the code before this commit** and passes
after.

`photo_ev_day` is raised in that scenario so the ring can accumulate on a step
down small enough not to hand the win to the drift detector. The existing
`scenario_photo` docstring, which said the ratio path can never fire, is updated
to say why drift is the only route *there* (ev stays above `photo_ev_day`).

### Suite result

60 pass / 2 fail. Both failures are `scenario_adc`, and they fail **identically
on unmodified `main`** on this host, so they are not from this change. Cause
looks like an ASan/LD_PRELOAD interaction rather than anything in ric: the shim
works correctly against a non-instrumented binary (open intercepted, ioctl
accepted, 4-byte value served), but with the ASan runtime preloaded first — as
`test-ric.sh` correctly does, since ASan aborts otherwise — ASan's own `open`
and `read` interceptors appear to resolve past the shim to libc. Happy to open
that separately if it does not reproduce for you.
