### PR TITLE
rvd: report the sensor rate in force, not the one that was refused

### DIFF
--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -499,7 +499,47 @@ int rvd_pipeline_init(rvd_state_t *st)
 			sensor_fps = 25;
 		/* Sensor 0 FPS via legacy ops */
 		ret = RSS_HAL_CALL(st->ops, isp_set_sensor_fps, st->hal_ctx, sensor_fps, 1);
-		if (ret != RSS_OK)
+		if (ret == RSS_ERR_NOTSUP) {
+			/*
+			 * Not a fault, so not a warning. An op a backend leaves out
+			 * answers NOTSUP through the RSS_HAL_CALL NULL guard, and a
+			 * backend may return it outright; either way the daemon is
+			 * expected to carry on (docs 10-hal-api.md 9.3). On some SoCs
+			 * the sensor rate is fixed when the mode is selected during
+			 * bring-up and cannot be changed afterwards -- the encoder
+			 * framerate is what varies there.
+			 *
+			 * Report the rate the sensor actually runs at rather than the
+			 * one that was refused. The refused number describes nothing,
+			 * and printing it invites the conclusion that the pipeline is
+			 * running at it.
+			 */
+			uint32_t num = 0, den = 0;
+			int actual = 0;
+
+			if (RSS_HAL_CALL(st->ops, isp_get_sensor_fps, st->hal_ctx, &num, &den) ==
+				    RSS_OK &&
+			    num && den)
+				actual = (int)((num + den / 2) / den);
+
+			if (!actual)
+				/* Nothing can report the rate, and sensor_fps may be the
+				 * 25 fallback rather than anything measured, so do not
+				 * present it as the sensor's. */
+				RSS_INFO("sensor0 fps: neither settable nor readable on this "
+					 "platform -- streams are configured against %d, which "
+					 "no source confirmed",
+					 sensor_fps);
+			else if (actual != sensor_fps)
+				RSS_INFO("sensor0 fps: not settable on this platform -- the "
+					 "sensor runs at %d, not the %d asked for, and streams "
+					 "are paced down from it",
+					 actual, sensor_fps);
+			else
+				RSS_INFO("sensor0 fps: not settable on this platform; the "
+					 "sensor runs at %d",
+					 actual);
+		} else if (ret != RSS_OK)
 			RSS_WARN("isp_set_sensor_fps failed: %d (non-fatal)", ret);
 		else
 			RSS_INFO("sensor0 fps: %d", sensor_fps);

--- a/tests/mock_hal.c
+++ b/tests/mock_hal.c
@@ -599,6 +599,48 @@ static int mock_isp_get_wb(void *ctx, rss_wb_config_t *wb_cfg)
 	return RSS_OK;
 }
 
+/*
+ * Sensor rate, and the two knobs that let a test choose which platform
+ * this mock imitates. Defaults reproduce a settable sensor with no
+ * read-back, so a suite that sets neither sees the behavior it always saw.
+ *
+ * RSS_MOCK_SENSOR_FPS_SET=notsup   the setter refuses as unsupported, as a
+ *                                  SoC whose rate is fixed at bring-up does
+ * RSS_MOCK_SENSOR_FPS_SET=error    the setter fails outright, which is a
+ *                                  fault and must still be reported as one
+ * RSS_MOCK_SENSOR_FPS_ACTUAL=<n>   the getter reports n fps; absent, it
+ *                                  refuses too, as a backend with no
+ *                                  read-back does
+ */
+static int mock_isp_set_sensor_fps(void *ctx, uint32_t fps_num, uint32_t fps_den)
+{
+	(void)ctx;
+	(void)fps_num;
+	(void)fps_den;
+	const char *mode = getenv("RSS_MOCK_SENSOR_FPS_SET");
+
+	if (mode && strcmp(mode, "notsup") == 0)
+		return RSS_ERR_NOTSUP;
+	if (mode && strcmp(mode, "error") == 0)
+		return RSS_ERR;
+	return RSS_OK;
+}
+
+static int mock_isp_get_sensor_fps(void *ctx, uint32_t *fps_num, uint32_t *fps_den)
+{
+	(void)ctx;
+	const char *v = getenv("RSS_MOCK_SENSOR_FPS_ACTUAL");
+	int actual = v ? atoi(v) : 0;
+
+	if (actual <= 0)
+		return RSS_ERR_NOTSUP;
+	if (!fps_num || !fps_den)
+		return RSS_ERR_INVAL;
+	*fps_num = (uint32_t)actual;
+	*fps_den = 1;
+	return RSS_OK;
+}
+
 /* ── Audio ── */
 
 static int mock_audio_init(void *ctx, const rss_audio_config_t *cfg)
@@ -770,7 +812,7 @@ static const rss_hal_ops_t mock_ops = {
 	.isp_set_hflip = (void *)mock_ok,
 	.isp_set_vflip = (void *)mock_ok,
 	.isp_set_running_mode = (void *)mock_ok,
-	.isp_set_sensor_fps = (void *)mock_ok,
+	.isp_set_sensor_fps = mock_isp_set_sensor_fps,
 	.isp_set_antiflicker = (void *)mock_ok,
 	.isp_set_bypass = (void *)mock_ok,
 	.isp_set_sinter_strength = (void *)mock_ok,
@@ -797,6 +839,7 @@ static const rss_hal_ops_t mock_ops = {
 	.isp_get_ae_comp = mock_isp_get_ae_comp,
 	.isp_get_max_again = (void *)mock_isp_get_u32,
 	.isp_get_max_dgain = (void *)mock_isp_get_u32,
+	.isp_get_sensor_fps = mock_isp_get_sensor_fps,
 	.isp_get_sinter_strength = (void *)mock_isp_get_u8,
 	.isp_get_temper_strength = (void *)mock_isp_get_u8,
 	.isp_get_dpc_strength = (void *)mock_isp_get_u8,

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -898,6 +898,77 @@ fi
 kill $ZOMBIE_PID 2>/dev/null || true
 wait $ZOMBIE_PID 2>/dev/null || true
 
+# ── Sensor rate on a platform that will not set it ──
+# A backend that leaves isp_set_sensor_fps out, or refuses it outright,
+# is behaving as specified, so rvd reports the rate in force instead of
+# repeating the number that was dropped. Which answer is honest depends
+# on what can be read back, hence three arms; the mock's two knobs pick
+# which platform it imitates. No [sensor] fps in the suite config and no
+# /proc/jz on the host, so rvd falls back to 25 -- the same case that
+# made the original line mislead.
+fps_arm() {
+    arm_name="$1"
+    arm_want="$2"
+    shift 2
+    pkill -f "$OUT/rvd" 2>/dev/null || true
+    sleep 1
+    start_daemon rvd env "$@" "$OUT/rvd" -c "$CONFIG" -f -d
+    sleep 2
+    if grep -q "$arm_want" "$LOG_DIR/rvd.log" 2>/dev/null; then
+        pass "$arm_name"
+    else
+        fail "$arm_name" "expected '$arm_want' in rvd log"
+        [ "$VERBOSE" = "1" ] && grep -i "sensor0 fps\|isp_set_sensor_fps" "$LOG_DIR/rvd.log"
+    fi
+    # Whichever arm fired, a documented refusal is not a fault: no
+    # warning about the call, and the arm's own line is not raised to one
+    if grep -q "isp_set_sensor_fps failed" "$LOG_DIR/rvd.log" 2>/dev/null ||
+        grep "sensor0 fps" "$LOG_DIR/rvd.log" 2>/dev/null | grep -q "WARN"; then
+        fail "$arm_name is not a fault" "a documented NOTSUP was reported as one"
+    else
+        pass "$arm_name is not a fault"
+    fi
+}
+
+echo ""
+echo "=== Sensor rate diagnostics ==="
+
+fps_arm "unsettable and unreadable names no rate as the sensor's" \
+    "no source confirmed" RSS_MOCK_SENSOR_FPS_SET=notsup
+fps_arm "unsettable but readable names the rate in force over the request" \
+    "sensor runs at 30, not the 25 asked for" \
+    RSS_MOCK_SENSOR_FPS_SET=notsup RSS_MOCK_SENSOR_FPS_ACTUAL=30
+fps_arm "unsettable and already at the requested rate says so plainly" \
+    "not settable on this platform; the sensor runs at 25" \
+    RSS_MOCK_SENSOR_FPS_SET=notsup RSS_MOCK_SENSOR_FPS_ACTUAL=25
+
+# A setter that fails for a real reason is still a fault: the three
+# arms above must not have swallowed the warning path with them
+pkill -f "$OUT/rvd" 2>/dev/null || true
+sleep 1
+start_daemon rvd env RSS_MOCK_SENSOR_FPS_SET=error "$OUT/rvd" -c "$CONFIG" -f -d
+sleep 2
+if grep -q "isp_set_sensor_fps failed" "$LOG_DIR/rvd.log" 2>/dev/null &&
+    ! grep -q "not settable on this platform\|no source confirmed" "$LOG_DIR/rvd.log" 2>/dev/null; then
+    pass "a setter that fails outright is still reported as a failure"
+else
+    fail "a setter that fails outright is still reported as a failure" \
+        "expected 'isp_set_sensor_fps failed' and none of the unsupported-platform lines"
+fi
+
+# Default mock: the setter works, so none of the three arms may appear
+pkill -f "$OUT/rvd" 2>/dev/null || true
+sleep 1
+start_daemon rvd "$OUT/rvd" -c "$CONFIG" -f -d
+sleep 2
+if grep -q "sensor0 fps: 25$" "$LOG_DIR/rvd.log" 2>/dev/null &&
+    ! grep -q "not settable on this platform\|no source confirmed" "$LOG_DIR/rvd.log" 2>/dev/null; then
+    pass "a settable sensor still reports the rate it was given"
+else
+    fail "a settable sensor still reports the rate it was given" \
+        "expected a plain 'sensor0 fps: 25' and no unsupported-platform line"
+fi
+
 if [ "$KEEP" = "1" ]; then
     echo ""
     echo "=== Keeping daemons running (Ctrl-C to stop) ==="


### PR DESCRIPTION
When a backend cannot set the sensor rate, `isp_set_sensor_fps` answers `NOTSUP` —
explicitly, or through the `RSS_HAL_CALL` NULL guard when the backend leaves the op
out. Either way the daemon is expected to carry on (docs `10-hal-api.md` 9.3), and
rvd warned instead:

```
isp_set_sensor_fps failed: -95 (non-fatal)
```

Two things are wrong with that. The refusal is a platform behaving as specified,
not a fault, and a log full of expected warnings is one nobody reads. And it says
nothing about the rate anything is running at, which leaves the reader to assume
the requested rate took effect.

This reports it at INFO and names the rate the sensor actually runs at, read back
with `isp_get_sensor_fps`. Three arms, because the honest answer differs with what
can be read: the sensor's rate when it is available, both numbers when the request
differed from it, and neither presented as fact when nothing can report it —
`sensor_fps` may be the 25 fallback rather than anything measured, so calling it
the sensor's rate would be the same mistake in a friendlier voice.

A setter that fails for a real reason still warns; only the `NOTSUP` branch
changes. Stream defaults still derive from the requested value in
`load_stream_config` — adopting the read-back rate there would be a behavior change
and belongs in its own PR.

**Scope note (corrected from an earlier version of this description):** rvd did not
warn on *every* optional-op refusal. The documented-optional tuning calls in
`rvd_pipeline.c` ignore their returns entirely; this fps call was the only startup
site that warned. The fix is aimed at the right place, but the original framing
overstated the blast radius.

**Testing.** The mock HAL gains two knobs so the suite can choose which platform it
imitates — `RSS_MOCK_SENSOR_FPS_SET` (setter succeeds / refuses as unsupported /
fails outright) and `RSS_MOCK_SENSOR_FPS_ACTUAL` (the rate the getter reports, or
none). Defaults reproduce the previous behavior. Five integration legs pin the three
arms, that a documented refusal is never reported as a fault, and that a real
failure still is.

Independent of the SigmaStar work — it needs nothing from raptor-hal and builds
against `main` as-is.
