### PR TITLE
rvd: do not require sensor identity the SDK already owns

### DIFF
--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -403,15 +403,27 @@ int rvd_pipeline_init(rvd_state_t *st)
 	}
 	st->sensor_count = multi_cfg.sensor_count;
 
+	/*
+	 * Both checks below exist to catch a daemon that cannot reach its
+	 * sensor. Where the SDK binds the sensor as its driver loads and
+	 * addresses it by index, the HAL resolves the sensor's identity itself
+	 * and neither value is reachable configuration -- an address in
+	 * particular is never read -- so requiring them would refuse to start a
+	 * camera that is fully able to.
+	 */
+	const rss_hal_caps_t *sensor_caps =
+		st->ops->get_caps ? st->ops->get_caps(st->hal_ctx) : NULL;
+	bool sdk_owns_sensor = sensor_caps && sensor_caps->sdk_owns_sensor;
+
 	/* Validate primary sensor */
-	if (!multi_cfg.sensors[0].name[0]) {
+	if (!multi_cfg.sensors[0].name[0] && !sdk_owns_sensor) {
 		RSS_FATAL("sensor name not in config and not in /proc/jz/sensor/sensor0/name");
 		rss_hal_destroy(st->hal_ctx);
 		st->hal_ctx = NULL;
 		return RSS_ERR;
 	}
 
-	if (multi_cfg.sensors[0].i2c_addr == 0) {
+	if (multi_cfg.sensors[0].i2c_addr == 0 && !sdk_owns_sensor) {
 		RSS_FATAL("i2c_addr not in config and not in /proc/jz/sensor/sensor0/i2c_addr");
 		rss_hal_destroy(st->hal_ctx);
 		st->hal_ctx = NULL;
@@ -613,14 +625,30 @@ int rvd_pipeline_init(rvd_state_t *st)
 		RSS_HAL_CALL(st->ops, isp_set_custom_mode_n, st->hal_ctx, s, 0);
 	}
 
-	/* ── 3d. Read actual sensor resolution from /proc ── */
+	/* ── 3d. Determine the actual sensor resolution ──
+	 *
+	 * procfs first (Ingenic's own registry), then the HAL, then config. The
+	 * HAL beats config because config only *requests* a mode: a backend that
+	 * enumerates sensor modes may have fallen back to native when the request
+	 * matched nothing, so the HAL holds the answer after that negotiation. */
 	int sensor_w = 0, sensor_h = 0;
+	const char *sensor_res_src = "/proc/jz/sensor";
 	{
 		sensor_w = read_sensor_proc_int(0, "width", 10, 0);
 		sensor_h = read_sensor_proc_int(0, "height", 10, 0);
 	}
+	if (sensor_w <= 0 || sensor_h <= 0) {
+		uint32_t hal_w = 0, hal_h = 0;
+		if (RSS_HAL_CALL(st->ops, isp_get_sensor_attr, st->hal_ctx, &hal_w, &hal_h) ==
+			    RSS_OK &&
+		    hal_w > 0 && hal_h > 0) {
+			sensor_w = (int)hal_w;
+			sensor_h = (int)hal_h;
+			sensor_res_src = "HAL";
+		}
+	}
 	if (sensor_w > 0 && sensor_h > 0) {
-		RSS_INFO("sensor resolution: %dx%d", sensor_w, sensor_h);
+		RSS_INFO("sensor resolution: %dx%d (from %s)", sensor_w, sensor_h, sensor_res_src);
 	} else {
 		/* T40/T41: /proc/jz/sensor doesn't exist — use stream0 config as reference */
 		int cfg_w = rss_config_get_int(cfg, "stream0", "width", 0);


### PR DESCRIPTION
**Depends on gtxaspec/raptor-hal#3**, which adds the `sdk_owns_sensor` capability.
Verified: this branch fails to compile against today's raptor-hal with
`'rss_hal_caps_t' has no member named 'sdk_owns_sensor'`, and builds once #3 is
applied.

### The problem

The sensor's name and I2C address come from config or `/proc/jz/sensor`, and both
are fatal when missing. That procfs tree is an Ingenic kernel's registry and does
not exist on other platforms, so an unconfigured boot cannot start at all there.

The address check is the sharper half. Where the SDK binds the sensor as its
driver loads and addresses it by index, the address is not merely unavailable —
it is never read by the backend at all. Requiring one means every config on such a
platform carries a fabricated value purely to satisfy a test that cannot mean
anything, and a camera fully able to run refuses to start without it.

### What changes

Both checks gate on the new `sdk_owns_sensor` capability, which is false on every
backend that exists today, so nothing changes for Ingenic. The keys still work and
still override wherever a backend consults them; they simply stop being mandatory
where the HAL resolves the sensor's identity itself.

Sensor resolution gains a HAL fallback for the same reason — procfs cannot answer
— and the log now names its source. The HAL is asked ahead of config deliberately:
config only *requests* a mode, and a backend that enumerates modes at runtime may
have fallen back to native when the request matched nothing, so the HAL holds the
answer after that negotiation rather than before it.

### Note on an earlier revision

This PR previously added a pre-init `sensor_detect` op for rvd to fetch the name
with. That was the wrong shape: tracing the consumers, upstream rvd uses the name
for nothing but its own non-empty check, and a backend that owns the sensor can
resolve the identity internally without being asked. The op has been dropped in
favour of the single capability, which is all the two checks actually need.

### Verified on hardware

An SSC30KQ with a GC4653, `[sensor]` naming neither a sensor nor an address:

```
rvd_pipeline.c: sensor0:  i2c=0x00 bus=0 id=0 mclk=1 vin=0 boot=0
hal_common.c:   sensor detect: "gc4653" (module sensor_gc4653_mipi in /proc/modules)
rvd_pipeline.c: sensor resolution: 2560x1440 (from HAL)
hal_isp.c:      isp: loaded tuning file /etc/sensors/gc4653.bin
```

rvd starts where it previously would have died on the missing address, the
backend resolves the sensor itself, and the tuning binary chosen is identical to
what the pre-init-op version chose. RTSP serves H.264 2560x1440 @30fps and a
decoded frame is correctly exposed and in colour. Day/night switching still
actuates the IR-cut GPIOs.
