### PR TITLE
rvd: pass a configured ISP tuning binary through to the HAL

### DIFF
--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -255,6 +255,12 @@ static void load_sensor_from_section(rss_config_t *cfg, const char *section,
 	if (vin < 0)
 		vin = 0;
 	sensor->vin_type = (rss_sensor_vin_t)vin;
+
+	/* Optional ISP tuning binary. Only a backend whose ISP is driven by a
+	 * tuning file reads this, and it derives the usual path from the sensor
+	 * name, so this stays empty unless the file lives somewhere unusual. */
+	rss_strlcpy(sensor->iq_file, rss_config_get_str(cfg, section, "iq_file", ""),
+		    sizeof(sensor->iq_file));
 }
 
 /* FS channel base for a given sensor index (hardware mapping) */


### PR DESCRIPTION
**Depends on gtxaspec/raptor-hal#3**, which adds `iq_file` to
`rss_sensor_config_t`. Verified: this branch fails to compile against today's
raptor-hal with `'rss_sensor_config_t' has no member named 'iq_file'`, and builds
once #3 is applied.

`[sensor] iq_file`, empty by default, copied through to the HAL.

Where a vendor's ISP is driven by a per-sensor tuning binary rather than by scalar
controls, loading the wrong one is not a subtle difference: the vendor 3A falls
back to a generic table and the image comes out miscoloured on a camera that is
otherwise streaming correctly. Backends derive the usual path from the sensor
name, so this only needs setting when the tuning file lives somewhere unusual.

Ingenic ignores it — there the equivalent tuning is compiled into the sensor
driver — so this is inert on every platform that has no use for it.
