### PR TITLE
rvd: read sensor orientation before hal_init

### DIFF
--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -255,6 +255,25 @@ static void load_sensor_from_section(rss_config_t *cfg, const char *section,
 	if (vin < 0)
 		vin = 0;
 	sensor->vin_type = (rss_sensor_vin_t)vin;
+
+	/* Orientation is read here, out of the [image] section rather than this
+	 * one, because some backends have to know it before the sensor starts:
+	 * where orientation is a sensor register the driver latches it during
+	 * bring-up, so a value that only arrives later via isp_set_hflip cannot
+	 * decide how the first frame comes out. The ISP setup still applies the
+	 * same keys through the ops, which is what backends that can change
+	 * orientation freely act on, and what a runtime change goes through. */
+	{
+		char img_sect[32];
+		const char *img = "image";
+
+		if (proc_idx > 0) {
+			snprintf(img_sect, sizeof(img_sect), "sensor%d_image", proc_idx);
+			img = img_sect;
+		}
+		sensor->hflip = rss_config_get_int(cfg, img, "hflip", 0) ? 1 : 0;
+		sensor->vflip = rss_config_get_int(cfg, img, "vflip", 0) ? 1 : 0;
+	}
 }
 
 /* FS channel base for a given sensor index (hardware mapping) */


### PR DESCRIPTION
**Depends on gtxaspec/raptor-hal#3**, which adds `hflip`/`vflip` to
`rss_sensor_config_t`. Verified: this branch fails to compile against today's
raptor-hal with `'rss_sensor_config_t' has no member named 'hflip'`, and builds
once #3 is applied.

`hflip`/`vflip` reach the sensor config, alongside the existing path that applies
them through `isp_set_hflip`/`isp_set_vflip` later.

Where orientation is a sensor register rather than an ISP attribute, the driver
latches it when its init routine runs as the sensor is enabled — inside
`hal_init`, before any caller can reach an ISP op. A value that only arrives
afterwards cannot decide how the first frame comes out, which is the case that
matters: a camera is mounted one way round and stays there.

The keys are unchanged and still live in `[image]`, since that is where an
operator expects them; this only reads them earlier as well. Backends that can
change orientation freely are unaffected and keep acting on the ops, which is also
what a runtime change still goes through.
