### PR TITLE
ric: say so when the ADC channel stops answering

### DIFF
--- a/ric/ric.h
+++ b/ric/ric.h
@@ -178,6 +178,8 @@ typedef struct {
 
 	/* ADC state */
 	bool adc_initialized;
+	int adc_fail_run;     /* consecutive failed reads, 0 while healthy */
+	bool adc_fail_warned; /* a warning has fired for the current run */
 
 	/* One-shot diagnostics: a missing signal is worth saying once, and
 	 * saying every poll instead is how a log stops being read. */

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -62,6 +62,59 @@ static int adc_read(int channel)
 	return (read(adc_fd, &value, sizeof(value)) == sizeof(value)) ? value : -1;
 }
 
+/*
+ * A photoresistor that stops answering is silent by nature: the read
+ * fails, the poll is skipped, and day/night freezes wherever it stood
+ * with nothing in the log to explain it. A start that fails is already
+ * reported and demoted to the luma trigger, so what is left uncovered
+ * is the device that opens and then goes quiet.
+ *
+ * Report a sustained run of failed reads rather than a single one --
+ * one skipped poll costs nothing and says nothing -- and repeat rarely
+ * enough that a log carrying the message for hours stays readable.
+ */
+#define ADC_FAIL_WARN_SEC 2
+#define ADC_FAIL_REPEAT_SEC 60
+
+static int adc_polls_per(const ric_state_t *st, int seconds)
+{
+	int ms = st->settings.poll_interval_ms > 0 ? st->settings.poll_interval_ms : 1000;
+	int polls = (seconds * 1000 + ms - 1) / ms;
+	return polls > 0 ? polls : 1;
+}
+
+static int adc_fail_secs(const ric_state_t *st)
+{
+	int ms = st->settings.poll_interval_ms > 0 ? st->settings.poll_interval_ms : 1000;
+	return (int)((long)st->adc_fail_run * ms / 1000);
+}
+
+static void adc_note_failed_read(ric_state_t *st)
+{
+	int first = adc_polls_per(st, ADC_FAIL_WARN_SEC);
+	int repeat = adc_polls_per(st, ADC_FAIL_REPEAT_SEC);
+	int run = ++st->adc_fail_run;
+
+	if (run < first || (run - first) % repeat != 0)
+		return;
+
+	RSS_WARN("ADC: channel %d has read nothing for %ds -- day/night is frozen in "
+		 "%s mode. Check the photoresistor wiring, or set [ircut] trigger to "
+		 "something this board can measure",
+		 st->settings.adc_channel, adc_fail_secs(st),
+		 st->current_mode == RIC_MODE_NIGHT ? "night" : "day");
+	st->adc_fail_warned = true;
+}
+
+static void adc_note_good_read(ric_state_t *st)
+{
+	if (st->adc_fail_warned)
+		RSS_INFO("ADC: channel %d reading again after %ds", st->settings.adc_channel,
+			 adc_fail_secs(st));
+	st->adc_fail_run = 0;
+	st->adc_fail_warned = false;
+}
+
 void ric_adc_cleanup(ric_state_t *st)
 {
 	if (adc_fd >= 0) {
@@ -400,9 +453,10 @@ void ric_poll_exposure(ric_state_t *st)
 		 */
 		int adc_val = adc_read(st->settings.adc_channel);
 		if (adc_val < 0) {
-			/* ADC read failed — skip this poll */
+			adc_note_failed_read(st);
 			return;
 		}
+		adc_note_good_read(st);
 		want_night = (adc_val < st->settings.adc_night);
 		want_day = (adc_val > st->settings.adc_day);
 		snprintf(why, sizeof(why), "adc=%d, night<%d day>%d", adc_val,

--- a/tests/ric_harness.py
+++ b/tests/ric_harness.py
@@ -719,6 +719,96 @@ def scenario_adc(stub, watch):
     ric.stop()
 
 
+def scenario_adc_dead(stub, watch):
+    """A photoresistor that opens and then stops answering must say so.
+    A device that will not open at all is already reported, and ric
+    demotes itself to the luma trigger; what was uncovered is the one
+    that reads fine and then goes quiet, freezing day/night with a
+    clean log. Reads are made to come up short by truncating the
+    backing file, which is what a dead channel looks like from ric."""
+    if not ADC_PRELOAD:
+        print("  SKIP  adc-dead: shim not built", flush=True)
+        return
+    backing = WORK + "/adc-dead-value"
+    hits = backing + ".hits"
+    try:
+        os.unlink(hits)
+    except OSError:
+        pass
+    with open(backing, "wb") as f:
+        f.write(struct.pack("<i", 700))  # bright side of adc_day=600
+    conf = GPIO_CONF + (
+        "trigger = adc\nadc_channel = 0\nadc_night = 200\n"
+        "adc_day = 600\nhysteresis_sec = 2\n"
+    )
+    stub.set_scene(luma=0, gain=0, ev=0)
+    ric = Ric(
+        "adc-dead",
+        conf,
+        env_extra={"LD_PRELOAD": ADC_PRELOAD, "RIC_ADC_BACKING": backing},
+    )
+    if not ric.wait_running():
+        result(False, "adc-dead: ric start", ric.read_log()[-300:])
+        ric.stop()
+        return
+    if "falling back to luma" in ric.read_log():
+        # Same inert-shim case scenario_adc documents; skip, or fail
+        # under strict mode, rather than lose the coverage quietly.
+        ric.stop()
+        if os.environ.get("RIC_SUITE_STRICT", "") == "1":
+            result(False, "adc-dead: shim provides the device", ric.read_log()[-300:])
+        else:
+            print("  SKIP  adc-dead: preload shim inert on this host", flush=True)
+        return
+    if not wait_for(lambda: os.path.exists(hits) and os.path.getsize(hits) > 0, 4):
+        result(False, "adc-dead: shim read interception engaged",
+               "polls running but no reads reached the shim (issue #18 shape)")
+        ric.stop()
+        return
+
+    # A brief gap is not a fault. Truncating the backing file fails every
+    # read, but for well under the sustained threshold -- the hit counter
+    # proves ric really polled across it, so this is not vacuous.
+    before = os.path.getsize(hits)
+    with open(backing, "wb"):
+        pass
+    time.sleep(0.6)
+    polled = os.path.getsize(hits) - before
+    with open(backing, "wb") as f:
+        f.write(struct.pack("<i", 700))
+    log = ric.read_log()
+    result(
+        polled >= 2 and "read nothing" not in log and "reading again" not in log,
+        "adc-dead: a brief gap in readings stays quiet",
+        "polls across the gap=%d, log=%s" % (polled, log[-200:]),
+    )
+
+    # A sustained one is: day/night is stuck and nothing else will say so.
+    mm = stub.mark()
+    with open(backing, "wb"):
+        pass
+    ok = wait_for(lambda: "read nothing" in ric.read_log(), 8)
+    result(ok, "adc-dead: a sustained outage is reported", ric.read_log()[-300:])
+    if ok:
+        # Rate-limited: the repeat is a minute out, so several more
+        # seconds of failing polls must not add a second line.
+        time.sleep(3)
+        n = len(re.findall(r"read nothing", ric.read_log()))
+        result(n == 1, "adc-dead: the outage warning is rate-limited",
+               "%d warnings across ~5s of failed polls" % n)
+
+    # Recovery is reported, and the poll path drives modes again rather
+    # than merely logging.
+    with open(backing, "wb") as f:
+        f.write(struct.pack("<i", 100))  # dark
+    ok = wait_for(lambda: "reading again" in ric.read_log(), 5)
+    result(ok, "adc-dead: recovery is reported", ric.read_log()[-300:])
+    ok = wait_for(lambda: "night" in stub.modes_since(mm), 6)
+    result(ok, "adc-dead: readings resume driving day/night",
+           str(stub.modes_since(mm)))
+    ric.stop()
+
+
 def scenario_pulse_width(stub, watch):
     """pulse_ms drives the dual-GPIO coil pulse (default 10, the value
     the fleet's ircut script has always used; thingino-firmware #1380).
@@ -1062,6 +1152,7 @@ def main():
         scenario_zero_exposure,
         scenario_partial_fields,
         scenario_adc,
+        scenario_adc_dead,
         scenario_disabled,
         scenario_json_discovery,
     ]


### PR DESCRIPTION
The second half of #18, as offered there. Independent of the shim work —
this is board behaviour, not test behaviour.

### What is silent today

```c
int adc_val = adc_read(st->settings.adc_channel);
if (adc_val < 0) {
	/* ADC read failed — skip this poll */
	return;
}
```

A channel that never opens is already covered: `ric_adc_start()` warns and
`ric_main.c` demotes the trigger to luma. What is left is the channel that
opens, reads for a while and then stops — the read fails every poll, the
branch returns, and day/night stays wherever it stood. Nothing is logged,
ever, so a camera stuck in day with a dead photoresistor looks exactly like a
camera watching a scene that does not change. That is what made #18 hard to
see from the outside: the same symptom, reached from the test side.

### What this adds

A run of failed reads is counted. Past two seconds of them, one warning:

```
WARN  ADC: channel 0 has read nothing for 2s -- day/night is frozen in day
      mode. Check the photoresistor wiring, or set [ircut] trigger to
      something this board can measure
```

then at most one more per minute while it lasts. The first good read
afterwards says so, at INFO, with the length of the outage:

```
INFO  ADC: channel 0 reading again after 74s
```

Three choices worth naming:

- **Two seconds, not one poll.** A single short read costs nothing and is not
  worth a line; only a sustained run means the sensor is gone.
- **Seconds, converted through `poll_interval_ms`.** A poll count would mean
  something different on every board. `adc_polls_per()` does the conversion,
  and guards a zero interval.
- **The frozen mode is in the message.** That is the symptom the operator is
  already looking at, so it is what connects the log line to the complaint.

### Tests

Five legs in a new `adc_dead` scenario. Reads are failed by truncating the
shim's backing file to zero — what a dead channel looks like from ric, and
the read still reaches the shim, so your hit counter keeps proving
interception across the whole scenario:

```
== scenario_adc_dead
  PASS  adc-dead: a brief gap in readings stays quiet
  PASS  adc-dead: a sustained outage is reported
  PASS  adc-dead: the outage warning is rate-limited
  PASS  adc-dead: recovery is reported
  PASS  adc-dead: readings resume driving day/night
```

The brief-gap leg checks the hit counter moved across the gap, so it cannot
pass by ric simply not having polled.

Mutation-checked, since a diagnostic that cannot fail a test is not tested:

| break | legs that fail |
|---|---|
| warning removed entirely (today's behaviour) | sustained outage, recovery |
| warn on every failed read (no threshold, no repeat gate) | brief gap, rate-limited |
| success never clears the run counter | recovery |

The fifth leg, that modes move again after recovery, has no mutation of its
own — it restates `scenario_adc`'s transition assertion on the far side of an
outage, and is there to stop the recovery line from being the only evidence
that polling resumed.

Suite goes 65 → 70, 0 fail, on `main` at `bc30cad`.
