### PR TITLE
rvd: add optional V4L2 OpenIMP video backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ ifeq ($(AUDIO_EFFECTS),1)
 CFLAGS += -DRAPTOR_AUDIO_EFFECTS
 endif
 
+ifeq ($(V4L2_OPENIMP),1)
+CFLAGS += -DRAPTOR_V4L2_OPENIMP
+endif
+
 ifeq ($(AAC),1)
 CFLAGS += -DRAPTOR_AAC
 LDFLAGS_AAC_ENC := -lfaac
@@ -248,7 +252,8 @@ ifneq ($(wildcard $(HAL_DIR)/Makefile),)
 build-raptor-hal:
 	@echo "  BUILD   raptor-hal"
 	$(Q)$(MAKE) -C $(HAL_DIR) PLATFORM=$(PLATFORM) CROSS_COMPILE=$(CROSS_COMPILE) \
-		$(if $(DEBUG),DEBUG=1,)
+		$(if $(DEBUG),DEBUG=1,) \
+		$(if $(filter 1,$(V4L2_OPENIMP)),V4L2_OPENIMP=1,)
 
 $(LIB_HAL_VIDEO_FILE) $(LIB_HAL_AUDIO_FILE): build-raptor-hal
 	@:

--- a/Makefile
+++ b/Makefile
@@ -191,8 +191,8 @@ LDFLAGS     := $(LDFLAGS_SYSROOT) -lpthread -lrt -latomic
 
 # MIPS page size: Ingenic SoCs use 4KB pages but the toolchain defaults to
 # 64KB max-page-size. Mismatched alignment causes SIGBUS on musl/uclibc.
-LDFLAGS_HAL += -Wl,-z,max-page-size=0x1000 -Wl,--gc-sections -Wl,--as-needed -Wl,-rpath,/usr/lib $(if $(DEBUG),,-flto)
-LDFLAGS     += -Wl,-z,max-page-size=0x1000 -Wl,--gc-sections -Wl,--as-needed -Wl,-rpath,/usr/lib $(if $(DEBUG),,-flto)
+LDFLAGS_HAL += -Wl,-z,max-page-size=0x1000 -Wl,--gc-sections -Wl,--as-needed -Wl,--enable-new-dtags,-rpath,/usr/lib $(if $(DEBUG),,-flto)
+LDFLAGS     += -Wl,-z,max-page-size=0x1000 -Wl,--gc-sections -Wl,--as-needed -Wl,--enable-new-dtags,-rpath,/usr/lib $(if $(DEBUG),,-flto)
 # rpath-link for local builds (finding .so at link time)
 LDFLAGS_HAL += -Wl,-rpath-link,$(CURDIR)/$(IPC_DIR) -Wl,-rpath-link,$(CURDIR)/$(COMMON_DIR)
 LDFLAGS     += -Wl,-rpath-link,$(CURDIR)/$(IPC_DIR) -Wl,-rpath-link,$(CURDIR)/$(COMMON_DIR)

--- a/README.md
+++ b/README.md
@@ -215,6 +215,33 @@ first (it creates the rings), then the rest; each daemon checks its own
 
 ## Configuration
 
+### Standalone V4L2 video
+
+RVD can use a public capture node instead of owning the private IMP frame
+graph:
+
+```ini
+[system]
+video_backend = v4l2
+video_device = /dev/video0
+```
+
+Build Raptor with `V4L2_OPENIMP=1`; selecting this backend without that build
+option fails explicitly while the default IMP backend remains available.
+
+The initial backend is deliberately narrow: one H.264 main stream, NV12 MMAP
+capture exported as DMA-BUF, and zero-copy submission to OpenIMP AVC. It does
+not create sub/JPEG/OSD/IVS channels. Runtime IDR requests and read-only stream
+configuration queries are supported; encoder reconfiguration and ISP effects
+return an explicit unsupported response. A separate ISP tuning service owns
+image policy so capture, encoding, and creative profiles have independent
+lifecycles.
+
+This first tranche is scaffolding around the existing IMP-shaped pipeline.
+The follow-up backend work will move V4L2 behind dedicated HAL operations and
+advertise its smaller surface through `get_caps`, instead of growing the
+temporary `v4l2_backend` branches as RVD evolves.
+
 All daemons share a single INI-style config file: `/etc/raptor.conf`.
 See [raptor-docs/23-rss-config.md](https://github.com/gtxaspec/raptor-docs/blob/main/23-rss-config.md)
 for the complete reference (all sections, keys, types, defaults).

--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -1,6 +1,12 @@
 # Raptor Streaming System configuration
 # See raptor-docs/23-rss-config.md for full option reference
 
+[system]
+# Video producer used by RVD. The V4L2 backend is currently a zero-copy T41
+# main-stream path: NV12 capture -> DMA-BUF -> OpenIMP H.264.
+video_backend = imp          # imp / v4l2
+video_device = /dev/video0
+
 [sensor]
 # All values auto-detected from /proc/jz/sensor if omitted
 # name = gc4653

--- a/rvd/rvd.h
+++ b/rvd/rvd.h
@@ -19,6 +19,76 @@
 #define RVD_OSD_RETRY_INTERVAL	50 /* check ticks (~5s at 10Hz) */
 #define RVD_OSD_NAME_LEN	32
 
+/* Keep the optional adapter out of normal Raptor builds. The wrappers let the
+ * pipeline reject a V4L2 configuration cleanly even when raptor-hal was built
+ * without the OpenIMP bridge. */
+#ifdef RAPTOR_V4L2_OPENIMP
+typedef rss_v4l2_h264_t rvd_v4l2_h264_t;
+#define rvd_v4l2_h264_create	    rss_v4l2_h264_create
+#define rvd_v4l2_h264_destroy	    rss_v4l2_h264_destroy
+#define rvd_v4l2_h264_start	    rss_v4l2_h264_start
+#define rvd_v4l2_h264_stop	    rss_v4l2_h264_stop
+#define rvd_v4l2_h264_poll	    rss_v4l2_h264_poll
+#define rvd_v4l2_h264_get_frame	    rss_v4l2_h264_get_frame
+#define rvd_v4l2_h264_release_frame rss_v4l2_h264_release_frame
+#define rvd_v4l2_h264_request_idr   rss_v4l2_h264_request_idr
+static inline bool rvd_v4l2_h264_supported(void)
+{
+	return true;
+}
+#else
+typedef void rvd_v4l2_h264_t;
+static inline bool rvd_v4l2_h264_supported(void)
+{
+	return false;
+}
+static inline int rvd_v4l2_h264_create(rvd_v4l2_h264_t **backend, const char *device,
+				       const rss_video_config_t *config)
+{
+	(void)backend;
+	(void)device;
+	(void)config;
+	return RSS_ERR_NOTSUP;
+}
+static inline void rvd_v4l2_h264_destroy(rvd_v4l2_h264_t *backend)
+{
+	(void)backend;
+}
+static inline int rvd_v4l2_h264_start(rvd_v4l2_h264_t *backend)
+{
+	(void)backend;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_stop(rvd_v4l2_h264_t *backend)
+{
+	(void)backend;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_poll(rvd_v4l2_h264_t *backend, uint32_t timeout_ms)
+{
+	(void)backend;
+	(void)timeout_ms;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_get_frame(rvd_v4l2_h264_t *backend, rss_frame_t *frame)
+{
+	(void)backend;
+	(void)frame;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_release_frame(rvd_v4l2_h264_t *backend, rss_frame_t *frame)
+{
+	(void)backend;
+	(void)frame;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_request_idr(rvd_v4l2_h264_t *backend)
+{
+	(void)backend;
+	return RSS_ERR_NOTSUP;
+}
+#endif
+
 /*
  * Thread safety: enc_cfg/fs_cfg are written only by the ctrl handler
  * (main thread). The encoder thread reads width/height once at startup
@@ -66,6 +136,10 @@ struct rvd_state {
 	/* HAL */
 	rss_hal_ctx_t *hal_ctx;
 	const rss_hal_ops_t *ops;
+	bool hal_initialized;
+	bool v4l2_backend;
+	char v4l2_device[64];
+	rvd_v4l2_h264_t *v4l2;
 
 	/* Sensors */
 	int sensor_count;

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -95,7 +95,11 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 			 * ask for, and an encoder may reject the request. */
 			if (st->streams[i].is_jpeg)
 				continue;
-			RSS_HAL_CALL(st->ops, enc_request_idr, st->hal_ctx, st->streams[i].chn);
+			if (st->v4l2_backend)
+				rvd_v4l2_h264_request_idr(st->v4l2);
+			else
+				RSS_HAL_CALL(st->ops, enc_request_idr, st->hal_ctx,
+					     st->streams[i].chn);
 		}
 		return rss_ctrl_resp_ok(resp, resp_size);
 	}
@@ -215,8 +219,9 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 		if (rss_json_get_int(cmd_json, "channel", &chn) == 0 && chn >= 0 &&
 		    chn < st->stream_count) {
 			uint32_t avg = 0;
-			RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx,
-				     st->streams[chn].chn, &avg);
+			if (!st->v4l2_backend)
+				RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx,
+					     st->streams[chn].chn, &avg);
 			cJSON *r = cJSON_CreateObject();
 			cJSON_AddStringToObject(r, "status", "ok");
 			cJSON_AddNumberToObject(r, "bitrate",
@@ -230,9 +235,11 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 	if (strcmp(cmd, "get-fps") == 0) {
 		if (rss_json_get_int(cmd_json, "channel", &chn) == 0 && chn >= 0 &&
 		    chn < st->stream_count) {
-			uint32_t num = 0, den = 0;
-			RSS_HAL_CALL(st->ops, enc_get_fps, st->hal_ctx, st->streams[chn].chn, &num,
-				     &den);
+			uint32_t num = st->streams[chn].enc_cfg.fps_num;
+			uint32_t den = st->streams[chn].enc_cfg.fps_den;
+			if (!st->v4l2_backend)
+				RSS_HAL_CALL(st->ops, enc_get_fps, st->hal_ctx,
+					     st->streams[chn].chn, &num, &den);
 			cJSON *r = cJSON_CreateObject();
 			cJSON_AddStringToObject(r, "status", "ok");
 			cJSON_AddNumberToObject(r, "fps_num", (double)num);
@@ -245,9 +252,10 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 	if (strcmp(cmd, "get-gop") == 0) {
 		if (rss_json_get_int(cmd_json, "channel", &chn) == 0 && chn >= 0 &&
 		    chn < st->stream_count) {
-			uint32_t gop = 0;
-			RSS_HAL_CALL(st->ops, enc_get_gop_attr, st->hal_ctx, st->streams[chn].chn,
-				     &gop);
+			uint32_t gop = st->streams[chn].enc_cfg.gop_length;
+			if (!st->v4l2_backend)
+				RSS_HAL_CALL(st->ops, enc_get_gop_attr, st->hal_ctx,
+					     st->streams[chn].chn, &gop);
 			cJSON *r = cJSON_CreateObject();
 			cJSON_AddStringToObject(r, "status", "ok");
 			cJSON_AddNumberToObject(r, "gop", (double)gop);
@@ -2171,7 +2179,9 @@ static int handle_config_cmd(const char *cmd, const char *cmd_json, rvd_state_t 
 		for (int i = 0; i < st->stream_count; i++) {
 			rvd_stream_t *s = &st->streams[i];
 			uint32_t avg_br = 0;
-			RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx, s->chn, &avg_br);
+			if (!st->v4l2_backend)
+				RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx, s->chn,
+					     &avg_br);
 			cJSON *item = cJSON_CreateObject();
 			cJSON_AddNumberToObject(item, "chn", (double)s->chn);
 			cJSON_AddNumberToObject(item, "w", (double)s->enc_cfg.width);
@@ -2236,8 +2246,9 @@ static int handle_config_cmd(const char *cmd, const char *cmd_json, rvd_state_t 
 		cJSON *arr = cJSON_AddArrayToObject(r, "streams");
 		for (int i = 0; i < st->stream_count; i++) {
 			uint32_t avg_br = 0;
-			RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx, st->streams[i].chn,
-				     &avg_br);
+			if (!st->v4l2_backend)
+				RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx,
+					     st->streams[i].chn, &avg_br);
 			cJSON *item = cJSON_CreateObject();
 			cJSON_AddNumberToObject(item, "chn", (double)st->streams[i].chn);
 			cJSON_AddNumberToObject(item, "w", (double)st->streams[i].enc_cfg.width);
@@ -2274,6 +2285,17 @@ int rvd_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 	char cmd[64];
 	if (rss_json_get_str(cmd_json, "cmd", cmd, sizeof(cmd)) != 0)
 		return rss_ctrl_resp_error(resp_buf, resp_buf_size, "missing cmd");
+
+	/* The standalone backend has no initialized IMP HAL graph. Keep its small
+	 * control surface explicit so a web/API request cannot fall through to an
+	 * operation on uninitialized SDK state. */
+	if (st->v4l2_backend && strcmp(cmd, "request-idr") != 0 &&
+	    strcmp(cmd, "get-bitrate") != 0 && strcmp(cmd, "get-fps") != 0 &&
+	    strcmp(cmd, "get-gop") != 0 && strcmp(cmd, "get-qp-bounds") != 0 &&
+	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "config-show") != 0 &&
+	    strcmp(cmd, "status") != 0)
+		return rss_ctrl_resp_error(resp_buf, resp_buf_size,
+					   "not supported by the V4L2 backend");
 
 	if ((len = handle_encoder_cmd(cmd, cmd_json, st, resp_buf, resp_buf_size)) > 0)
 		return len;

--- a/rvd/rvd_frame_loop.c
+++ b/rvd/rvd_frame_loop.c
@@ -30,10 +30,14 @@ static void publish_utc_mapping(rvd_state_t *st, rss_ring_t *ring)
 {
 	int64_t media_a = 0, media_b = 0;
 
-	if (RSS_HAL_CALL(st->ops, sys_get_timestamp, st->hal_ctx, &media_a) != RSS_OK)
+	if (st->v4l2_backend)
+		media_a = rss_timestamp_us();
+	else if (RSS_HAL_CALL(st->ops, sys_get_timestamp, st->hal_ctx, &media_a) != RSS_OK)
 		return;
 	int64_t wall = rss_wallclock_us();
-	if (RSS_HAL_CALL(st->ops, sys_get_timestamp, st->hal_ctx, &media_b) != RSS_OK)
+	if (st->v4l2_backend)
+		media_b = rss_timestamp_us();
+	else if (RSS_HAL_CALL(st->ops, sys_get_timestamp, st->hal_ctx, &media_b) != RSS_OK)
 		return;
 	if (media_b - media_a > 1000)
 		return; /* preempted mid-sample, retry next interval */
@@ -82,7 +86,9 @@ void *rvd_encoder_thread(void *arg)
 	 * each configured frame. Skipped at near-continuous rates
 	 * where start/stop churn would exceed the savings.
 	 */
-	const rss_hal_caps_t *caps = st->ops->get_caps ? st->ops->get_caps(st->hal_ctx) : NULL;
+	const rss_hal_caps_t *caps = NULL;
+	if (!st->v4l2_backend && st->ops->get_caps)
+		caps = st->ops->get_caps(st->hal_ctx);
 	int64_t pulse_interval_us = 0;
 	bool pulse =
 		s->is_jpeg && s->jpeg_idle && caps && caps->jpeg_pulse && s->enc_cfg.fps_num > 0;
@@ -156,12 +162,20 @@ void *rvd_encoder_thread(void *arg)
 		 * consulting the ring's codec, and this loop is the only place
 		 * that acts on it, so one gate here covers every raiser.
 		 */
-		if (s->ring && rss_ring_check_idr(s->ring) && !s->is_jpeg)
-			RSS_HAL_CALL(st->ops, enc_request_idr, st->hal_ctx, s->chn);
+		if (s->ring && rss_ring_check_idr(s->ring) && !s->is_jpeg) {
+			if (st->v4l2_backend)
+				rvd_v4l2_h264_request_idr(st->v4l2);
+			else
+				RSS_HAL_CALL(st->ops, enc_request_idr, st->hal_ctx, s->chn);
+		}
 
 		/* Block until encoder has a frame (up to 1 second timeout).
 		 * Each thread blocks independently so channels don't starve. */
-		int ret = RSS_HAL_CALL(st->ops, enc_poll, st->hal_ctx, s->chn, 1000);
+		int ret;
+		if (st->v4l2_backend)
+			ret = rvd_v4l2_h264_poll(st->v4l2, 1000);
+		else
+			ret = RSS_HAL_CALL(st->ops, enc_poll, st->hal_ctx, s->chn, 1000);
 		if (ret != RSS_OK) {
 			/* Timeouts are normal (sensor idle, JPEG on-demand stopped).
 			 * Log on repeated failures to catch flaky sensor/encoder. */
@@ -173,7 +187,10 @@ void *rvd_encoder_thread(void *arg)
 		poll_errors = 0;
 
 		rss_frame_t frame;
-		ret = RSS_HAL_CALL(st->ops, enc_get_frame, st->hal_ctx, s->chn, &frame);
+		if (st->v4l2_backend)
+			ret = rvd_v4l2_h264_get_frame(st->v4l2, &frame);
+		else
+			ret = RSS_HAL_CALL(st->ops, enc_get_frame, st->hal_ctx, s->chn, &frame);
 		if (ret == -EAGAIN)
 			continue; /* no frame this time (empty stream / JPEG fps divider) */
 		if (ret != RSS_OK) {
@@ -298,7 +315,10 @@ void *rvd_encoder_thread(void *arg)
 			}
 		}
 
-		RSS_HAL_CALL(st->ops, enc_release_frame, st->hal_ctx, s->chn, &frame);
+		if (st->v4l2_backend)
+			rvd_v4l2_h264_release_frame(st->v4l2, &frame);
+		else
+			RSS_HAL_CALL(st->ops, enc_release_frame, st->hal_ctx, s->chn, &frame);
 
 		frame_count++;
 

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -165,6 +165,51 @@ static const char *rc_mode_str(rss_rc_mode_t m)
 	}
 }
 
+static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
+			       int default_w, int default_h, int default_fps, int default_br);
+
+static int rvd_pipeline_init_v4l2(rvd_state_t *st)
+{
+	rvd_stream_t *stream = &st->streams[0];
+	const char *device;
+	int ret;
+
+	device = rss_config_get_str(st->cfg, "system", "video_device", "/dev/video0");
+	rss_strlcpy(st->v4l2_device, device, sizeof(st->v4l2_device));
+	st->v4l2_backend = true;
+	st->sensor_count = 1;
+	st->stream_count = 1;
+	st->jpeg_count = 0;
+	st->refmode = false;
+	st->refmode_shm = false;
+	st->osd_enabled = false;
+	st->use_isp_osd = false;
+	st->ivs_enabled = false;
+	atomic_store(&st->ivs_active, false);
+
+	load_stream_config(st->cfg, "stream0", stream, 2560, 1440, 25, 8000000);
+	stream->fs_chn = 0;
+	stream->chn = 0;
+	stream->sensor_idx = 0;
+	rss_strlcpy(stream->cfg_sect, "stream0", sizeof(stream->cfg_sect));
+	if (stream->enc_cfg.codec != RSS_CODEC_H264) {
+		RSS_FATAL("V4L2 backend currently requires stream0 codec=h264");
+		return RSS_ERR_NOTSUP;
+	}
+	if (rss_config_get_bool(st->cfg, "stream1", "enabled", true) ||
+	    rss_config_get_bool(st->cfg, "jpeg", "enabled", true) ||
+	    rss_config_get_bool(st->cfg, "osd", "enabled", true) ||
+	    rss_config_get_bool(st->cfg, "motion", "enabled", false))
+		RSS_WARN("V4L2 backend exposes stream0 only; sub/JPEG/OSD/IVS are disabled");
+
+	ret = rvd_stream_init(st, 0);
+	if (ret != RSS_OK)
+		return ret;
+	st->pipeline_ready = true;
+	RSS_INFO("pipeline ready: V4L2 %s -> OpenIMP AVC -> main ring", st->v4l2_device);
+	return RSS_OK;
+}
+
 /* Load one stream's config from INI section */
 static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
 			       int default_w, int default_h, int default_fps, int default_br)
@@ -388,6 +433,14 @@ int rvd_pipeline_init(rvd_state_t *st)
 		return RSS_ERR;
 	}
 	st->ops = rss_hal_get_ops(st->hal_ctx);
+	if (strcasecmp(rss_config_get_str(cfg, "system", "video_backend", "imp"), "v4l2") == 0) {
+		if (!rvd_v4l2_h264_supported()) {
+			RSS_FATAL("V4L2/OpenIMP backend requested but Raptor was built without "
+				  "V4L2_OPENIMP=1");
+			return RSS_ERR_NOTSUP;
+		}
+		return rvd_pipeline_init_v4l2(st);
+	}
 
 	/* ── 2. Sensor config ── */
 	rss_multi_sensor_config_t multi_cfg = {0};
@@ -508,6 +561,7 @@ int rvd_pipeline_init(rvd_state_t *st)
 		RSS_FATAL("HAL init failed: %d", ret);
 		return ret;
 	}
+	st->hal_initialized = true;
 
 	/* Log system info */
 	{
@@ -1062,6 +1116,17 @@ int rvd_stream_init(rvd_state_t *st, int idx)
 	rvd_stream_t *s = &st->streams[idx];
 	rss_config_t *cfg = st->cfg;
 	int ret;
+
+	if (st->v4l2_backend) {
+		if (idx != 0)
+			return RSS_ERR_NOTSUP;
+		ret = rvd_v4l2_h264_create(&st->v4l2, st->v4l2_device, &s->enc_cfg);
+		if (ret != RSS_OK) {
+			RSS_ERROR("V4L2/OpenIMP backend create failed: %d", ret);
+			return ret;
+		}
+		goto create_ring;
+	}
 	/* ── Encoder group + channel ── */
 	if (s->is_jpeg) {
 		int video_grp = find_video_group(st, s->fs_chn);
@@ -1258,6 +1323,7 @@ int rvd_stream_init(rvd_state_t *st, int idx)
 		RSS_DEBUG("stream%d bind: %d stages", idx, chain_len);
 	}
 
+create_ring:
 	/* ── Create ring (or reuse existing across encoder restart) ── */
 	if (s->ring) {
 		rvd_stream_publish_info(st, idx);
@@ -1402,6 +1468,11 @@ int rvd_stream_init(rvd_state_t *st, int idx)
 
 	/* Rollback on failure */
 fail_ring:
+	if (st->v4l2_backend) {
+		rvd_v4l2_h264_destroy(st->v4l2);
+		st->v4l2 = NULL;
+		return ret;
+	}
 fail_bind:
 	if (st->osd_enabled && !s->is_jpeg) {
 		pthread_mutex_lock(&st->osd_lock);
@@ -1434,12 +1505,15 @@ void rvd_stream_stop(rvd_state_t *st, int idx)
 
 	/* Stop encoder */
 	if (s->enabled) {
-		RSS_HAL_CALL(st->ops, enc_stop, st->hal_ctx, s->chn);
+		if (st->v4l2_backend)
+			rvd_v4l2_h264_stop(st->v4l2);
+		else
+			RSS_HAL_CALL(st->ops, enc_stop, st->hal_ctx, s->chn);
 		s->enabled = false;
 	}
 
 	/* Disable framesource (JPEG shares FS, caller handles ordering) */
-	if (!s->is_jpeg)
+	if (!s->is_jpeg && !st->v4l2_backend)
 		RSS_HAL_CALL(st->ops, fs_disable_channel, st->hal_ctx, s->fs_chn);
 
 	RSS_DEBUG("stream%d stopped", idx);
@@ -1452,6 +1526,12 @@ void rvd_stream_deinit(rvd_state_t *st, int idx)
 	/* Skip if never successfully initialized (or already rolled back) */
 	if (!s->ring)
 		return;
+	if (st->v4l2_backend) {
+		rvd_v4l2_h264_destroy(st->v4l2);
+		st->v4l2 = NULL;
+		RSS_DEBUG("stream%d V4L2 backend deinit complete", idx);
+		return;
+	}
 
 	/* Unbind chain in reverse */
 	if (!s->is_jpeg) {
@@ -1512,9 +1592,17 @@ int rvd_stream_start(rvd_state_t *st, int idx)
 	if (s->is_jpeg && s->jpeg_idle) {
 		s->enabled = false;
 	} else {
-		if (!s->is_jpeg)
+		if (st->v4l2_backend) {
+			int backend_ret = rvd_v4l2_h264_start(st->v4l2);
+			if (backend_ret != RSS_OK) {
+				RSS_ERROR("stream%d: V4L2 start failed: %d", idx, backend_ret);
+				return backend_ret;
+			}
+		} else if (!s->is_jpeg) {
 			RSS_HAL_CALL(st->ops, fs_enable_channel, st->hal_ctx, s->fs_chn);
-		RSS_HAL_CALL(st->ops, enc_start, st->hal_ctx, s->chn);
+		}
+		if (!st->v4l2_backend)
+			RSS_HAL_CALL(st->ops, enc_start, st->hal_ctx, s->chn);
 		s->enabled = true;
 	}
 
@@ -1531,10 +1619,13 @@ int rvd_stream_start(rvd_state_t *st, int idx)
 		RSS_ERROR("stream%d: pthread_create failed: %d", idx, ret);
 		atomic_store(&st->stream_active[idx], false);
 		if (s->enabled) {
-			RSS_HAL_CALL(st->ops, enc_stop, st->hal_ctx, s->chn);
+			if (st->v4l2_backend)
+				rvd_v4l2_h264_stop(st->v4l2);
+			else
+				RSS_HAL_CALL(st->ops, enc_stop, st->hal_ctx, s->chn);
 			s->enabled = false;
 		}
-		if (!s->is_jpeg)
+		if (!s->is_jpeg && !st->v4l2_backend)
 			RSS_HAL_CALL(st->ops, fs_disable_channel, st->hal_ctx, s->fs_chn);
 		return RSS_ERR;
 	}
@@ -1570,7 +1661,7 @@ void rvd_pipeline_deinit(rvd_state_t *st)
 		rvd_ivs_deinit(st);
 
 	/* Destroy framesource channels (Layer 1 — only on full shutdown) */
-	for (int i = st->stream_count - 1; i >= 0; i--) {
+	for (int i = st->stream_count - 1; i >= 0 && !st->v4l2_backend; i--) {
 		if (!st->streams[i].is_jpeg)
 			RSS_HAL_CALL(st->ops, fs_destroy_channel, st->hal_ctx,
 				     st->streams[i].fs_chn);
@@ -1579,7 +1670,8 @@ void rvd_pipeline_deinit(rvd_state_t *st)
 	pthread_mutex_destroy(&st->osd_lock);
 
 	if (st->hal_ctx) {
-		RSS_HAL_CALL(st->ops, deinit, st->hal_ctx);
+		if (st->hal_initialized)
+			RSS_HAL_CALL(st->ops, deinit, st->hal_ctx);
 		rss_hal_destroy(st->hal_ctx);
 		st->hal_ctx = NULL;
 	}

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -198,6 +198,19 @@ mkdir -p "$LOG_DIR/rec"
 
 CONFIG="$LOG_DIR/test.conf"
 
+# Backend-selection variants. The base config intentionally omits [system],
+# exercising the established implicit IMP default.
+{
+    printf '[system]\nvideo_backend = imp\n\n'
+    cat "$CONFIG"
+} > "$LOG_DIR/test-imp.conf"
+{
+    printf '[system]\nvideo_backend = v4l2\nvideo_device = /dev/video0\n\n'
+    cat "$CONFIG"
+} > "$LOG_DIR/test-v4l2.conf"
+IMP_CONFIG="$LOG_DIR/test-imp.conf"
+V4L2_CONFIG="$LOG_DIR/test-v4l2.conf"
+
 # Clean stale state from previous runs
 mkdir -p /var/run/rss 2>/dev/null || { sudo mkdir -p /var/run/rss && sudo chmod 1777 /var/run/rss; }
 rm -f /var/run/rss/*.pid /var/run/rss/*.sock 2>/dev/null
@@ -221,6 +234,36 @@ if ! kill -0 "$RINGS_PID" 2>/dev/null; then
     cat "$LOG_DIR/rings.log"
     exit 1
 fi
+
+echo "=== Backend selection tests ==="
+if "$OUT/rvd" -c "$V4L2_CONFIG" -f -d > "$LOG_DIR/rvd-v4l2-disabled.log" 2>&1; then
+    fail "disabled V4L2 backend is rejected" "rvd unexpectedly exited successfully"
+elif grep -q "V4L2/OpenIMP backend requested but Raptor was built without V4L2_OPENIMP=1" \
+        "$LOG_DIR/rvd-v4l2-disabled.log"; then
+    pass "disabled V4L2 backend is rejected with an explicit message"
+else
+    fail "disabled V4L2 backend is rejected" "explicit diagnostic missing"
+fi
+
+# Start the explicit IMP form far enough to record its initialized topology,
+# then compare it with the normal omitted-key daemon below.
+"$OUT/rvd" -c "$IMP_CONFIG" -f -d > "$LOG_DIR/rvd-imp-explicit.log" 2>&1 &
+IMP_PID=$!
+IMP_PIPELINE=""
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    IMP_PIPELINE=$(sed -n 's/.*\(pipeline ready:.*\)/\1/p' \
+        "$LOG_DIR/rvd-imp-explicit.log" | tail -1)
+    [ -n "$IMP_PIPELINE" ] && break
+    kill -0 "$IMP_PID" 2>/dev/null || break
+    sleep 0.1
+done
+if [ -n "$IMP_PIPELINE" ] && kill -0 "$IMP_PID" 2>/dev/null; then
+    pass "explicit IMP backend initializes"
+else
+    fail "explicit IMP backend initializes" "pipeline did not become ready"
+fi
+kill "$IMP_PID" 2>/dev/null || true
+wait "$IMP_PID" 2>/dev/null || true
 
 echo "=== Starting daemons ==="
 
@@ -257,6 +300,14 @@ start_daemon rmr "$OUT/rmr" -c "$CONFIG" -f -d
 # Let daemons settle
 sleep 2
 
+DEFAULT_PIPELINE=$(sed -n 's/.*\(pipeline ready:.*\)/\1/p' "$LOG_DIR/rvd.log" | tail -1)
+if [ -n "$IMP_PIPELINE" ] && [ "$DEFAULT_PIPELINE" = "$IMP_PIPELINE" ]; then
+    pass "explicit IMP backend matches the omitted-key default"
+else
+    fail "explicit IMP backend matches the omitted-key default" \
+        "explicit='$IMP_PIPELINE' default='$DEFAULT_PIPELINE'"
+fi
+
 # ── Tests ──
 
 echo ""
@@ -281,6 +332,27 @@ check_contains "set-fps" "ok" "$OUT/raptorctl" rvd set-fps 0 30
 check_contains "set-qp-bounds" "ok" "$OUT/raptorctl" rvd set-qp-bounds 0 15 45
 check_contains "set-rc-mode" "ok" "$OUT/raptorctl" rvd set-rc-mode 0 cbr
 check_contains "request-idr" "ok" "$OUT/raptorctl" rvd request-idr
+
+# Pin keyframe truth across the full producer-to-ring path. RSD waits for this
+# bit before releasing a new client, so an IDR NAL marked non-key is a stream
+# outage rather than cosmetic metadata.
+timeout 5 "$OUT/ringdump" main -f -s -n 8 > "$LOG_DIR/keyframe-ring.log" 2>&1 &
+KEY_READER_PID=$!
+sleep 0.2
+"$OUT/ringdump" main -i > /dev/null 2>&1 || true
+wait "$KEY_READER_PID" 2>/dev/null || true
+if grep -q 'nal=H264_IDR.*key=1' "$LOG_DIR/keyframe-ring.log"; then
+    pass "requested H.264 IDR reaches the ring as a keyframe"
+else
+    fail "requested H.264 IDR reaches the ring as a keyframe" \
+        "no H264_IDR/key=1 frame observed"
+fi
+if grep -Eq 'nal=H264_IDR.*key=0|nal=H264_SLICE.*key=1' \
+        "$LOG_DIR/keyframe-ring.log"; then
+    fail "ring key flag agrees with H.264 NAL type" "mismatched frame metadata"
+else
+    pass "ring key flag agrees with H.264 NAL type"
+fi
 
 # Advanced encoder
 check_contains "enc-set gop_mode" "ok" "$OUT/raptorctl" rvd enc-set 0 gop_mode 0


### PR DESCRIPTION
## Summary

- add an opt-in RVD backend for `/dev/video0` NV12 capture and OpenIMP H.264 encoding
- publish the encoded main stream through the existing Raptor ring, preserving downstream RTSP, WebRTC, recording, and other consumers
- keep the established IMP backend as the configuration and build default
- reject V4L2 configuration explicitly unless Raptor is built with `V4L2_OPENIMP=1`
- limit the first tranche to one H.264 main stream; substream, JPEG, OSD, IVS, and live encoder mutation remain explicitly unsupported
- preserve current JPEG IDR gating while rebasing the work onto current Raptor main

Depends on gtxaspec/raptor-hal#5 for the optional bridge API. This supports themactep/thingino-firmware#1368; the firmware enables the build flag only when OpenIMP is selected.

## Compatibility

Normal builds use current upstream Raptor-HAL without the bridge API. The disabled adapter compiles to stubs, `video_backend` defaults to `imp`, and no V4L2/OpenIMP symbols are linked into the normal RVD binary.

## Validation

- host `-Werror` syntax build of all RVD sources against current upstream Raptor-HAL, with the feature disabled
- host ASan/UBSan RVD link and CLI smoke test using the mock HAL
- T41 uClibc RVD build against current upstream Raptor plus raptor-hal#5 with `V4L2_OPENIMP=1`
- T41 uClibc normal RVD build against unmodified current upstream Raptor-HAL
- confirmed the normal binary has no OpenIMP/V4L2 imports
- `git diff --check`

Signed-off-by: Matt Davis <matteius@gmail.com>