### PR TITLE
rvd: republish the ring header when a stream's rate changes

### DIFF
--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -636,6 +636,22 @@ void *rsd_video_reader_thread(void *arg)
 				       : 30;
 		uint32_t frame_dur = 90000 / fps;
 
+		/*
+		 * The session thread builds a=framerate from the cache below, and
+		 * a rate change reaches the header in place -- the ring is not
+		 * reopened and nobody is woken -- so the reconnect path above
+		 * never sees it. Refresh it here, where the header is already in
+		 * hand for the pacing above. Rate only: a codec or geometry
+		 * change has to reset clients, which stays the reconnect path's
+		 * job.
+		 */
+		if (rhdr->fps_num != rctx->last_fps_num || rhdr->fps_den != rctx->last_fps_den) {
+			RSS_INFO("ring[%d]: rate now %u/%u fps", rctx->idx, rhdr->fps_num,
+				 rhdr->fps_den);
+			rctx->last_fps_num = rhdr->fps_num;
+			rctx->last_fps_den = rhdr->fps_den;
+		}
+
 		for (int burst = 0; burst < 8; burst++) {
 			uint32_t length;
 			rss_ring_slot_t meta;

--- a/rvd/rvd.h
+++ b/rvd/rvd.h
@@ -164,6 +164,9 @@ void rvd_stream_deinit(rvd_state_t *st, int idx);
 int rvd_stream_start(rvd_state_t *st, int idx);
 void rvd_stream_stop(rvd_state_t *st, int idx);
 
+/* Republish geometry and rate into the ring header; rsd's SDP reads it. */
+void rvd_stream_publish_info(rvd_state_t *st, int idx);
+
 /* rvd_frame_loop.c */
 void rvd_frame_loop(rvd_state_t *st, volatile sig_atomic_t *running);
 void *rvd_encoder_thread(void *arg);

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -182,7 +182,9 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 					       st->streams[chn].chn, val, 1);
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.fps_num = val;
+				st->streams[chn].enc_cfg.fps_den = 1;
 				rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, "fps", val);
+				rvd_stream_publish_info(st, chn);
 			}
 			return fmt_hal_result(resp, resp_size, ret);
 		}

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -60,6 +60,43 @@ static uint8_t rvd_level_idc(int width, int height)
 	return 52; /* 5.2 */
 }
 
+/*
+ * Publish a stream's geometry and rate into its ring header.
+ *
+ * rsd builds the SDP from this header, so anything that changes a stream at
+ * runtime has to call it again -- otherwise the next client to connect is
+ * told the value the stream started with.
+ */
+void rvd_stream_publish_info(rvd_state_t *st, int idx)
+{
+	rvd_stream_t *s;
+
+	if (!st || idx < 0 || idx >= st->stream_count)
+		return;
+
+	s = &st->streams[idx];
+	if (!s->ring)
+		return;
+
+	if (s->is_jpeg) {
+		int jpeg_idx = 0;
+		for (int j = 0; j < st->jpeg_count; j++) {
+			if (st->jpeg_streams[j] == idx) {
+				jpeg_idx = j;
+				break;
+			}
+		}
+		rss_ring_set_stream_info(s->ring, RVD_JPEG_STREAM_ID_BASE + jpeg_idx, RSS_CODEC_JPEG,
+					 s->enc_cfg.width, s->enc_cfg.height, s->enc_cfg.fps_num,
+					 s->enc_cfg.fps_den, 0, 0);
+	} else {
+		rss_ring_set_stream_info(s->ring, idx, s->enc_cfg.codec, s->enc_cfg.width,
+					 s->enc_cfg.height, s->enc_cfg.fps_num, s->enc_cfg.fps_den,
+					 rvd_profile_idc(s->enc_cfg.profile),
+					 rvd_level_idc(s->enc_cfg.width, s->enc_cfg.height));
+	}
+}
+
 /* Parse codec string from config */
 static rss_codec_t parse_codec(const char *s)
 {
@@ -1183,25 +1220,7 @@ int rvd_stream_init(rvd_state_t *st, int idx)
 
 	/* ── Create ring (or reuse existing across encoder restart) ── */
 	if (s->ring) {
-		if (s->is_jpeg) {
-			int jpeg_idx = 0;
-			for (int j = 0; j < st->jpeg_count; j++) {
-				if (st->jpeg_streams[j] == idx) {
-					jpeg_idx = j;
-					break;
-				}
-			}
-			rss_ring_set_stream_info(s->ring, RVD_JPEG_STREAM_ID_BASE + jpeg_idx,
-						 RSS_CODEC_JPEG, s->enc_cfg.width,
-						 s->enc_cfg.height, s->enc_cfg.fps_num,
-						 s->enc_cfg.fps_den, 0, 0);
-		} else {
-			rss_ring_set_stream_info(
-				s->ring, idx, s->enc_cfg.codec, s->enc_cfg.width, s->enc_cfg.height,
-				s->enc_cfg.fps_num, s->enc_cfg.fps_den,
-				rvd_profile_idc(s->enc_cfg.profile),
-				rvd_level_idc(s->enc_cfg.width, s->enc_cfg.height));
-		}
+		rvd_stream_publish_info(st, idx);
 		RSS_DEBUG("stream%d ring: reused", idx);
 	} else {
 		int local = s->fs_chn - fs_base_channel(s->sensor_idx);

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -86,9 +86,9 @@ void rvd_stream_publish_info(rvd_state_t *st, int idx)
 				break;
 			}
 		}
-		rss_ring_set_stream_info(s->ring, RVD_JPEG_STREAM_ID_BASE + jpeg_idx, RSS_CODEC_JPEG,
-					 s->enc_cfg.width, s->enc_cfg.height, s->enc_cfg.fps_num,
-					 s->enc_cfg.fps_den, 0, 0);
+		rss_ring_set_stream_info(s->ring, RVD_JPEG_STREAM_ID_BASE + jpeg_idx,
+					 RSS_CODEC_JPEG, s->enc_cfg.width, s->enc_cfg.height,
+					 s->enc_cfg.fps_num, s->enc_cfg.fps_den, 0, 0);
 	} else {
 		rss_ring_set_stream_info(s->ring, idx, s->enc_cfg.codec, s->enc_cfg.width,
 					 s->enc_cfg.height, s->enc_cfg.fps_num, s->enc_cfg.fps_den,

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -416,6 +416,35 @@ else
     skip "H.265 SDP" "DESCRIBE failed or codec mismatch"
 fi
 
+# ── A rate change reaches the next client's SDP ──
+# rvd republishes the ring header on set-fps, but rsd answers DESCRIBE from
+# a cache it filled when it opened the ring, and an in-place republish wakes
+# nobody. Without a refresh in the reader every client after the change is
+# still told the old rate -- which the ring header cannot show, so this goes
+# through DESCRIBE.
+sdp_framerate() {
+    rtsp_describe 15554 stream0 | sed -n 's/.*a=framerate:\([0-9][0-9]*\).*/\1/p' | head -1
+}
+
+FPS_SDP_BEFORE=$(sdp_framerate)
+"$OUT/raptorctl" rvd set-fps 0 12 > /dev/null 2>&1
+sleep 2
+FPS_SDP_AFTER=$(sdp_framerate)
+if [ "$FPS_SDP_AFTER" = "12" ] && [ "$FPS_SDP_BEFORE" != "12" ]; then
+    pass "set-fps moves a=framerate for the next client ($FPS_SDP_BEFORE -> $FPS_SDP_AFTER)"
+elif [ -z "$FPS_SDP_BEFORE" ]; then
+    skip "set-fps moves a=framerate" "no a=framerate in the SDP (DESCRIBE failed?)"
+else
+    fail "set-fps moves a=framerate for the next client" \
+        "before=$FPS_SDP_BEFORE after=$FPS_SDP_AFTER, expected 12"
+fi
+
+# Hand the following legs back the rate they had
+if [ -n "$FPS_SDP_BEFORE" ]; then
+    "$OUT/raptorctl" rvd set-fps 0 "$FPS_SDP_BEFORE" > /dev/null 2>&1
+    sleep 1
+fi
+
 # ffprobe (if available — best RTSP test tool)
 if command -v ffprobe > /dev/null 2>&1; then
     # ffprobe with timeout — exit 124 (timeout) means it connected and received data

--- a/tests/test_ctrl.c
+++ b/tests/test_ctrl.c
@@ -226,6 +226,12 @@ void rvd_stream_stop(rvd_state_t *st, int idx)
 	(void)idx;
 }
 
+void rvd_stream_publish_info(rvd_state_t *st, int idx)
+{
+	(void)st;
+	(void)idx;
+}
+
 void rvd_osd_set_privacy(rvd_state_t *st, bool enable, int stream)
 {
 	if (stream >= 0 && stream < st->stream_count) {

--- a/tests/test_ctrl.c
+++ b/tests/test_ctrl.c
@@ -54,6 +54,10 @@ static struct {
 	/* ISP */
 	int set_brightness;
 	int brightness_stored;
+
+	/* Ring header republishes, and the channel of the last one */
+	int publish_count;
+	int publish_chn;
 } rec;
 
 static void rec_reset(void)
@@ -226,10 +230,15 @@ void rvd_stream_stop(rvd_state_t *st, int idx)
 	(void)idx;
 }
 
+/*
+ * Recorded, not discarded: republishing the ring header is the whole point
+ * of the set-fps path, and nothing else in the daemon's reach observes it.
+ */
 void rvd_stream_publish_info(rvd_state_t *st, int idx)
 {
 	(void)st;
-	(void)idx;
+	rec.publish_count++;
+	rec.publish_chn = idx;
 }
 
 void rvd_osd_set_privacy(rvd_state_t *st, bool enable, int stream)
@@ -423,6 +432,57 @@ TEST set_fps_updates_state_on_success(void)
 	call("{\"cmd\":\"set-fps\",\"channel\":0,\"value\":30}");
 	ASSERT_EQ(30, (int)st.streams[0].enc_cfg.fps_num);
 	ASSERT_EQ(30, rss_config_get_int(st.cfg, "stream0", "fps", 0));
+	/* The HAL was asked for a whole number of frames per second... */
+	ASSERT_EQ_FMT(30u, rec.set_fps_num, "%u");
+	ASSERT_EQ_FMT(1u, rec.set_fps_den, "%u");
+	/* ...so the cached denominator has to say so too, or state and
+	 * hardware disagree the moment anything reads the pair back. */
+	ASSERT_EQ(1, (int)st.streams[0].enc_cfg.fps_den);
+	/* And the ring header carries the new rate to rsd's SDP. */
+	ASSERT_EQ_FMT(1, rec.publish_count, "%d");
+	ASSERT_EQ_FMT(0, rec.publish_chn, "%d");
+	teardown();
+	PASS();
+}
+
+/* A stale den is the defect: 5/2 fps then set-fps 30 must not leave 30/2. */
+TEST set_fps_resets_a_fractional_den(void)
+{
+	setup();
+	st.streams[0].enc_cfg.fps_num = 5;
+	st.streams[0].enc_cfg.fps_den = 2;
+	rec.return_val = 0;
+	call("{\"cmd\":\"set-fps\",\"channel\":0,\"value\":30}");
+	ASSERT_EQ(30, (int)st.streams[0].enc_cfg.fps_num);
+	ASSERT_EQ(1, (int)st.streams[0].enc_cfg.fps_den);
+	teardown();
+	PASS();
+}
+
+/* The republish has to name the channel that changed, not always the first. */
+TEST set_fps_publishes_the_channel_it_changed(void)
+{
+	setup();
+	rec.return_val = 0;
+	call("{\"cmd\":\"set-fps\",\"channel\":1,\"value\":20}");
+	ASSERT_EQ(20, (int)st.streams[1].enc_cfg.fps_num);
+	ASSERT_EQ_FMT(1, rec.publish_count, "%d");
+	ASSERT_EQ_FMT(1, rec.publish_chn, "%d");
+	/* stream0 was not touched */
+	ASSERT_EQ(25, (int)st.streams[0].enc_cfg.fps_num);
+	teardown();
+	PASS();
+}
+
+/* A refused rate must leave the header alone -- publishing a rate the
+ * hardware rejected would advertise a lie to every new client. */
+TEST set_fps_no_publish_on_hal_failure(void)
+{
+	setup();
+	rec.return_val = -1;
+	call("{\"cmd\":\"set-fps\",\"channel\":0,\"value\":60}");
+	ASSERT_EQ(25, (int)st.streams[0].enc_cfg.fps_num);
+	ASSERT_EQ_FMT(0, rec.publish_count, "%d");
 	teardown();
 	PASS();
 }
@@ -928,6 +988,9 @@ SUITE(ctrl_suite)
 	RUN_TEST(set_bitrate_no_state_change_on_hal_failure);
 	RUN_TEST(set_gop_no_state_change_on_hal_failure);
 	RUN_TEST(set_fps_updates_state_on_success);
+	RUN_TEST(set_fps_resets_a_fractional_den);
+	RUN_TEST(set_fps_publishes_the_channel_it_changed);
+	RUN_TEST(set_fps_no_publish_on_hal_failure);
 	RUN_TEST(set_qp_bounds_atomic_update);
 	RUN_TEST(set_qp_bounds_neither_updated_on_failure);
 	RUN_TEST(set_rc_mode_stores_enum_not_string);


### PR DESCRIPTION
rsd builds the SDP framerate from the ring header, and rvd writes that header
once at pipeline setup. A runtime `set-fps` therefore changes the stream while
every client that connects afterwards is still told the rate it started with.

Extract the publish into `rvd_stream_publish_info` so the ctrl handler can reuse
it, and set `fps_den` alongside `fps_num` — the handler had left it at whatever
the stream started with.

`tests/test_ctrl.c` gains a stub for the new function beside the other pipeline
stubs, because the ctrl suite links `rvd_ctrl.c` without `rvd_pipeline.c`.

### Verification

- Builds clean for `PLATFORM=T31` with a mipsel/uClibc toolchain.
- 220/220 host tests pass.
- Measured on an SSC30KQ running the out-of-tree SigmaStar backend, which is
  where this was found: `set-fps 1 10` moves the header from `5/1` to `10/1`,
  matching the 10.2 fps `ringdump` measures on the ring itself.

Note the delivered rate only follows the request on that board because of a
separate backend-side fix; this change is about the header the SDP is built
from, which was stale regardless of backend.