### PR TITLE
rad: summarise a burst of audio clock resyncs instead of logging each one

### DIFF
--- a/build-asan.sh
+++ b/build-asan.sh
@@ -423,10 +423,10 @@ fi
 FAAC_CFLAGS="-I$FAAC_DIR/include"
 FAAC_LIBS="$FAAC_BUILD/libfaac.a"
 
-for f in rad_main.c rad_codec.c rad_codec_g711.c rad_codec_l16.c rad_codec_aac.c rad_codec_opus.c; do
+for f in rad_main.c rad_resync.c rad_codec.c rad_codec_g711.c rad_codec_l16.c rad_codec_aac.c rad_codec_opus.c; do
   $CC $CFLAGS $HAL_CFLAGS $FAAC_CFLAGS -c "$RAPTOR_DIR/rad/$f" -o "$OUT/${f%.c}.o"
 done
-$CC -o "$OUT/rad" "$OUT"/rad_main.o "$OUT"/rad_codec.o "$OUT"/rad_codec_g711.o \
+$CC -o "$OUT/rad" "$OUT"/rad_main.o "$OUT"/rad_resync.o "$OUT"/rad_codec.o "$OUT"/rad_codec_g711.o \
     "$OUT"/rad_codec_l16.o "$OUT"/rad_codec_aac.o "$OUT"/rad_codec_opus.o \
     $LIBS_HAL $FAAC_LIBS -lopus $LDFLAGS
 echo "  -> rad"

--- a/rad/Makefile
+++ b/rad/Makefile
@@ -1,4 +1,4 @@
-SRCS := rad_main.c rad_codec.c rad_codec_g711.c rad_codec_l16.c rad_codec_aac.c rad_codec_opus.c
+SRCS := rad_main.c rad_resync.c rad_codec.c rad_codec_g711.c rad_codec_l16.c rad_codec_aac.c rad_codec_opus.c
 OBJS := $(SRCS:.c=.o)
 BIN  := rad
 

--- a/rad/rad_main.c
+++ b/rad/rad_main.c
@@ -27,6 +27,7 @@
 #include <rss_common.h>
 
 #include "rad.h"
+#include "rad_resync.h"
 
 /*
  * Synthetic audio clock slew (AI loop). The clock advances by sample
@@ -51,69 +52,6 @@
 #define RAD_SYNTH_RESYNC_AHEAD_US  1000000
 #define RAD_SYNTH_NUDGE_BAND_US	   20000
 #define RAD_SYNTH_NUDGE_US	   1000
-
-/*
- * Resync reporting.
- *
- * One resync is worth a line of its own: it names audio the SDK lost. But a
- * sustained loss episode fires one every time the error climbs back over the
- * threshold, and hundreds of identical warnings evict everything else from a
- * 64 KB syslog ring -- destroying the very context needed to explain them. So
- * the first is logged in full, the rest are counted, and the episode is
- * summarised when it ends or once a minute while it continues.
- *
- * The summary is the useful diagnostic anyway: a count and a total say how
- * much audio went missing and how fast, which a stream of identical
- * threshold-sized corrections does not.
- */
-#define RAD_RESYNC_QUIET_US   5000000  /* no resync for this long ends an episode */
-#define RAD_RESYNC_SUMMARY_US 60000000 /* a longer episode reports in as it runs */
-
-typedef struct {
-	int64_t open_us; /* wall time the window opened; 0 when none is open */
-	int64_t last_us; /* wall time of the most recent resync */
-	int64_t total_us;
-	unsigned int count;
-} rad_resync_log_t;
-
-static void rad_resync_summarise(rad_resync_log_t *r, int64_t now_us)
-{
-	if (r->count > 1)
-		RSS_WARN("audio clock resynced %u times in %llds, %+lldms corrected in total",
-			 r->count, (long long)((r->last_us - r->open_us) / 1000000),
-			 (long long)(r->total_us / 1000));
-
-	r->count = 0;
-	r->total_us = 0;
-	r->open_us = now_us;
-}
-
-static void rad_resync_note(rad_resync_log_t *r, int64_t now_us, int64_t corr_us)
-{
-	if (!r->open_us) {
-		RSS_WARN("audio clock resync %+lldms (lost samples or stall)",
-			 (long long)(corr_us / 1000));
-		r->open_us = now_us;
-	}
-
-	r->last_us = now_us;
-	r->total_us += corr_us;
-	r->count++;
-}
-
-/* Called every chunk, so an episode that stops still gets its summary. */
-static void rad_resync_tick(rad_resync_log_t *r, int64_t now_us)
-{
-	if (!r->open_us)
-		return;
-
-	if (now_us - r->last_us >= RAD_RESYNC_QUIET_US) {
-		rad_resync_summarise(r, now_us);
-		r->open_us = 0;
-	} else if (now_us - r->open_us >= RAD_RESYNC_SUMMARY_US) {
-		rad_resync_summarise(r, now_us);
-	}
-}
 
 /* ── AO thread context (needed by ctrl handler for ao-enable/ao-disable) ── */
 
@@ -1341,7 +1279,7 @@ int main(int argc, char **argv)
 
 	int64_t synth_audio_ts = rss_timestamp_us();
 	int64_t last_read_us = 0; /* pacing detector for the clock slew */
-	rad_resync_log_t resync_log = { 0 };
+	rad_resync_log_t resync_log = {0};
 
 	ctrl_ctx = (rad_ctrl_ctx_t){
 		.cfg = dctx.cfg,

--- a/rad/rad_main.c
+++ b/rad/rad_main.c
@@ -52,6 +52,69 @@
 #define RAD_SYNTH_NUDGE_BAND_US	   20000
 #define RAD_SYNTH_NUDGE_US	   1000
 
+/*
+ * Resync reporting.
+ *
+ * One resync is worth a line of its own: it names audio the SDK lost. But a
+ * sustained loss episode fires one every time the error climbs back over the
+ * threshold, and hundreds of identical warnings evict everything else from a
+ * 64 KB syslog ring -- destroying the very context needed to explain them. So
+ * the first is logged in full, the rest are counted, and the episode is
+ * summarised when it ends or once a minute while it continues.
+ *
+ * The summary is the useful diagnostic anyway: a count and a total say how
+ * much audio went missing and how fast, which a stream of identical
+ * threshold-sized corrections does not.
+ */
+#define RAD_RESYNC_QUIET_US   5000000  /* no resync for this long ends an episode */
+#define RAD_RESYNC_SUMMARY_US 60000000 /* a longer episode reports in as it runs */
+
+typedef struct {
+	int64_t open_us; /* wall time the window opened; 0 when none is open */
+	int64_t last_us; /* wall time of the most recent resync */
+	int64_t total_us;
+	unsigned int count;
+} rad_resync_log_t;
+
+static void rad_resync_summarise(rad_resync_log_t *r, int64_t now_us)
+{
+	if (r->count > 1)
+		RSS_WARN("audio clock resynced %u times in %llds, %+lldms corrected in total",
+			 r->count, (long long)((r->last_us - r->open_us) / 1000000),
+			 (long long)(r->total_us / 1000));
+
+	r->count = 0;
+	r->total_us = 0;
+	r->open_us = now_us;
+}
+
+static void rad_resync_note(rad_resync_log_t *r, int64_t now_us, int64_t corr_us)
+{
+	if (!r->open_us) {
+		RSS_WARN("audio clock resync %+lldms (lost samples or stall)",
+			 (long long)(corr_us / 1000));
+		r->open_us = now_us;
+	}
+
+	r->last_us = now_us;
+	r->total_us += corr_us;
+	r->count++;
+}
+
+/* Called every chunk, so an episode that stops still gets its summary. */
+static void rad_resync_tick(rad_resync_log_t *r, int64_t now_us)
+{
+	if (!r->open_us)
+		return;
+
+	if (now_us - r->last_us >= RAD_RESYNC_QUIET_US) {
+		rad_resync_summarise(r, now_us);
+		r->open_us = 0;
+	} else if (now_us - r->open_us >= RAD_RESYNC_SUMMARY_US) {
+		rad_resync_summarise(r, now_us);
+	}
+}
+
 /* ── AO thread context (needed by ctrl handler for ao-enable/ao-disable) ── */
 
 typedef struct {
@@ -1278,6 +1341,7 @@ int main(int argc, char **argv)
 
 	int64_t synth_audio_ts = rss_timestamp_us();
 	int64_t last_read_us = 0; /* pacing detector for the clock slew */
+	rad_resync_log_t resync_log = { 0 };
 
 	ctrl_ctx = (rad_ctrl_ctx_t){
 		.cfg = dctx.cfg,
@@ -1381,10 +1445,10 @@ int main(int argc, char **argv)
 		last_read_us = now_us;
 		bool live_paced = read_gap >= 15000 && read_gap <= 150000;
 		int64_t clk_err = now_us - synth_audio_ts;
+		rad_resync_tick(&resync_log, now_us);
 		if (clk_err > RAD_SYNTH_RESYNC_BEHIND_US || clk_err < -RAD_SYNTH_RESYNC_AHEAD_US) {
 			if (live_paced) {
-				RSS_WARN("audio clock resync %+lldms (lost samples or stall)",
-					 (long long)(clk_err / 1000));
+				rad_resync_note(&resync_log, now_us, clk_err);
 				synth_audio_ts += clk_err;
 			}
 		} else if (clk_err > RAD_SYNTH_NUDGE_BAND_US) {

--- a/rad/rad_resync.c
+++ b/rad/rad_resync.c
@@ -1,0 +1,54 @@
+/*
+ * rad_resync.c -- Reporting for bursts of synthetic-audio-clock resyncs.
+ */
+#include "rad_resync.h"
+
+#include <rss_common.h>
+
+static void rad_resync_report(const rad_resync_log_t *r)
+{
+	/*
+	 * A count of one is the resync rad_resync_note already logged in full,
+	 * so a summary would only repeat it. Because the counters run for the
+	 * whole episode, that test means the same thing at every report.
+	 */
+	if (r->count < 2)
+		return;
+
+	RSS_WARN("audio clock resynced %u times in %llds: net %+lldms, absolute %lldms", r->count,
+		 (long long)((r->last_us - r->open_us) / 1000000), (long long)(r->net_us / 1000),
+		 (long long)(r->moved_us / 1000));
+}
+
+void rad_resync_note(rad_resync_log_t *r, int64_t now_us, int64_t corr_us)
+{
+	if (!r->open_us) {
+		RSS_WARN("audio clock resync %+lldms (lost samples or stall)",
+			 (long long)(corr_us / 1000));
+		r->open_us = now_us;
+		r->report_us = now_us;
+	}
+
+	r->last_us = now_us;
+	r->net_us += corr_us;
+	r->moved_us += corr_us < 0 ? -corr_us : corr_us;
+	r->count++;
+}
+
+void rad_resync_tick(rad_resync_log_t *r, int64_t now_us)
+{
+	if (!r->open_us)
+		return;
+
+	if (now_us - r->last_us >= RAD_RESYNC_QUIET_US) {
+		rad_resync_report(r);
+		*r = (rad_resync_log_t){0};
+	} else if (now_us - r->report_us >= RAD_RESYNC_SUMMARY_US) {
+		/*
+		 * Paced off the last report rather than the episode start, or
+		 * every chunk after the first minute reports again.
+		 */
+		rad_resync_report(r);
+		r->report_us = now_us;
+	}
+}

--- a/rad/rad_resync.h
+++ b/rad/rad_resync.h
@@ -1,0 +1,46 @@
+/*
+ * rad_resync.h -- Reporting for bursts of synthetic-audio-clock resyncs.
+ *
+ * One resync is worth a line of its own: it names audio the SDK lost. But a
+ * sustained loss episode fires one every time the error climbs back over the
+ * threshold, and hundreds of identical warnings evict everything else from a
+ * 64 KB syslog ring -- destroying the very context needed to explain them. So
+ * the first is logged in full, the rest are counted, and the episode is
+ * summarised when it ends and once a minute while it continues.
+ *
+ * The summary is the better diagnostic anyway: a count and a total say how
+ * much audio went missing and how fast, which a stream of identical
+ * threshold-sized corrections does not.
+ */
+#ifndef RAD_RESYNC_H
+#define RAD_RESYNC_H
+
+#include <stdint.h>
+
+#define RAD_RESYNC_QUIET_US   5000000  /* no resync for this long ends an episode */
+#define RAD_RESYNC_SUMMARY_US 60000000 /* a longer episode reports in as it runs */
+
+/*
+ * Counters accumulate for the whole episode and are cleared only when it
+ * closes. A periodic report that reset them would leave the next report
+ * unable to tell a fresh resync from the one already logged in full.
+ */
+typedef struct {
+	int64_t open_us;   /* when the episode began; 0 when none is open */
+	int64_t last_us;   /* the most recent resync */
+	int64_t report_us; /* the last periodic report, for pacing the next */
+	int64_t net_us;	   /* signed sum: corrections in both directions cancel */
+	int64_t moved_us;  /* unsigned sum, which a cancelling net would hide */
+	unsigned int count;
+} rad_resync_log_t;
+
+/* Record a resync of corr_us. Logs the first of an episode in full. */
+void rad_resync_note(rad_resync_log_t *r, int64_t now_us, int64_t corr_us);
+
+/*
+ * Advance the clock. Call every chunk, not only on a resync, or an episode
+ * that simply stops waits for a resync that never comes to be summarised.
+ */
+void rad_resync_tick(rad_resync_log_t *r, int64_t now_us);
+
+#endif /* RAD_RESYNC_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,8 +21,8 @@ CFLAGS = -Wall -Wextra -std=$(RAPTOR_STD) -D_GNU_SOURCE -g $(SAN_FLAGS) $(RAPTOR
 LDFLAGS = $(SAN_FLAGS) -lpthread -lrt -lm
 
 TEST_SRCS = main.c test_ric_json.c test_nal.c test_prebuf.c test_mux.c test_codec.c test_sdp.c test_ring.c test_rsp.c \
-            test_ctrl.c test_sign.c test_storage.c
-LIB_SRCS = ../ric/ric_json.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
+            test_ctrl.c test_sign.c test_storage.c test_resync.c
+LIB_SRCS = ../ric/ric_json.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c ../rad/rad_resync.c \
            ../../raptor-common/src/rss_util.c ../../raptor-common/src/rss_log.c \
            ../../raptor-common/src/cJSON.c \
            ../../raptor-common/third_party/monocypher/monocypher.c \

--- a/tests/main.c
+++ b/tests/main.c
@@ -17,6 +17,7 @@ extern SUITE(rsp_state_suite);
 extern SUITE(ctrl_suite);
 extern SUITE(sign_suite);
 extern SUITE(storage_suite);
+extern SUITE(resync_suite);
 
 GREATEST_MAIN_DEFS();
 
@@ -40,5 +41,6 @@ int main(int argc, char **argv)
 	RUN_SUITE(ctrl_suite);
 	RUN_SUITE(sign_suite);
 	RUN_SUITE(storage_suite);
+	RUN_SUITE(resync_suite);
 	GREATEST_MAIN_END();
 }

--- a/tests/test_resync.c
+++ b/tests/test_resync.c
@@ -1,0 +1,201 @@
+#include "greatest.h"
+#include "../rad/rad_resync.h"
+
+#include <rss_common.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/*
+ * The tracker's whole behavior is what it logs, so the legs read the log
+ * back. rss_log's file target flushes every line, so a temp file is the
+ * cheapest way to see exactly what an operator would see.
+ */
+
+#define CAP_MAX 8192
+
+static char cap_path[64];
+static char cap_buf[CAP_MAX];
+
+static void cap_begin(void)
+{
+	snprintf(cap_path, sizeof(cap_path), "/tmp/rad_resync_cap.%d", (int)getpid());
+	unlink(cap_path);
+	rss_log_init("radtest", RSS_LOG_WARN, RSS_LOG_TARGET_FILE, cap_path);
+}
+
+static const char *cap_end(void)
+{
+	FILE *f = fopen(cap_path, "r");
+	size_t n = 0;
+
+	cap_buf[0] = '\0';
+	if (f) {
+		n = fread(cap_buf, 1, sizeof(cap_buf) - 1, f);
+		fclose(f);
+	}
+	cap_buf[n] = '\0';
+	/* Put logging back where the rest of the suite expects it. */
+	rss_log_init("tests", RSS_LOG_DEBUG, RSS_LOG_TARGET_STDERR, NULL);
+	unlink(cap_path);
+	return cap_buf;
+}
+
+static int cap_count(const char *hay, const char *needle)
+{
+	int n = 0;
+	const char *p = hay;
+
+	while ((p = strstr(p, needle)) != NULL) {
+		n++;
+		p += strlen(needle);
+	}
+	return n;
+}
+
+#define S(sec) ((int64_t)(sec) * 1000000LL)
+#define MS(ms) ((int64_t)(ms) * 1000LL)
+
+/* A single resync is worth its own line, and must not also be summarised. */
+TEST resync_lone_stays_one_line(void)
+{
+	rad_resync_log_t r = {0};
+
+	cap_begin();
+	rad_resync_note(&r, S(10), MS(150));
+	/* Long enough after to close the episode. */
+	rad_resync_tick(&r, S(10) + RAD_RESYNC_QUIET_US);
+	const char *log = cap_end();
+
+	ASSERT_EQ_FMT(1, cap_count(log, "audio clock resync +150ms"), "%d");
+	ASSERT_EQ_FMT(0, cap_count(log, "times in"), "%d");
+	/* Closed: the counters are clear and the next resync logs in full. */
+	ASSERT_EQ_FMT(0, (int)r.count, "%d");
+	ASSERT_EQ_FMT(0, (long long)r.open_us == 0 ? 0 : 1, "%d");
+	PASS();
+}
+
+/* A burst logs once, then one summary naming count, span and totals. */
+TEST resync_burst_summarised_once(void)
+{
+	rad_resync_log_t r = {0};
+	int64_t t = S(100);
+
+	cap_begin();
+	for (int i = 0; i < 12; i++) {
+		rad_resync_tick(&r, t);
+		rad_resync_note(&r, t, MS(150));
+		t += S(1);
+	}
+	/* Episode stops; the closing tick must summarise it. */
+	rad_resync_tick(&r, t + RAD_RESYNC_QUIET_US);
+	const char *log = cap_end();
+
+	ASSERT_EQ_FMT(1, cap_count(log, "audio clock resync +150ms"), "%d");
+	ASSERT_EQ_FMT(1, cap_count(log, "times in"), "%d");
+	/* 12 resyncs spanning 11s, 150ms each, all in one direction. */
+	ASSERT(strstr(log, "resynced 12 times in 11s: net +1800ms, absolute 1800ms") != NULL);
+	PASS();
+}
+
+/* An episode longer than a minute reports as it runs, cumulatively. */
+TEST resync_long_episode_reports_each_minute(void)
+{
+	rad_resync_log_t r = {0};
+	int64_t t = S(1000);
+
+	cap_begin();
+	/* A resync every second for 130s: two periodic reports, then a close. */
+	for (int i = 0; i < 130; i++) {
+		rad_resync_tick(&r, t);
+		rad_resync_note(&r, t, MS(150));
+		t += S(1);
+	}
+	rad_resync_tick(&r, t + RAD_RESYNC_QUIET_US);
+	const char *log = cap_end();
+
+	/* Two minute reports plus the closing one -- not one per chunk. */
+	ASSERT_EQ_FMT(3, cap_count(log, "times in"), "%d");
+	/* Cumulative, so the counts rise and the last covers the episode. */
+	ASSERT(strstr(log, "resynced 60 times in 59s") != NULL);
+	ASSERT(strstr(log, "resynced 120 times in 119s") != NULL);
+	ASSERT(strstr(log, "resynced 130 times in 129s") != NULL);
+	PASS();
+}
+
+/*
+ * The leg the reviewed shape failed. A periodic report used to reset the
+ * counters while leaving the window open, so a lone resync arriving after
+ * one was counted into a fresh accumulator and then dropped by the
+ * count-of-one guard -- never logged in full, never summarised.
+ */
+TEST resync_tail_after_periodic_report_is_reported(void)
+{
+	rad_resync_log_t r = {0};
+	int64_t t = S(2000);
+
+	cap_begin();
+	/*
+	 * 61 seconds of resyncs: the tick at the 60s mark reports, and the
+	 * resync right behind it is the only one after that report.
+	 */
+	for (int i = 0; i <= 60; i++) {
+		rad_resync_tick(&r, t);
+		rad_resync_note(&r, t, MS(150));
+		t += S(1);
+	}
+	rad_resync_tick(&r, t - S(1) + RAD_RESYNC_QUIET_US);
+	const char *log = cap_end();
+
+	/* The periodic report covers 60; the closing one must cover all 61. */
+	ASSERT(strstr(log, "resynced 60 times in 59s") != NULL);
+	ASSERT(strstr(log, "resynced 61 times in 60s") != NULL);
+	ASSERT_EQ_FMT(2, cap_count(log, "times in"), "%d");
+	PASS();
+}
+
+/* Corrections in both directions cancel in the net, so report magnitude too. */
+TEST resync_alternating_signs_show_in_absolute(void)
+{
+	rad_resync_log_t r = {0};
+	int64_t t = S(3000);
+
+	cap_begin();
+	for (int i = 0; i < 10; i++) {
+		rad_resync_tick(&r, t);
+		rad_resync_note(&r, t, i % 2 ? MS(-1000) : MS(1000));
+		t += S(1);
+	}
+	rad_resync_tick(&r, t + RAD_RESYNC_QUIET_US);
+	const char *log = cap_end();
+
+	/* Net cancels to zero; absolute says 10s of audio was moved. */
+	ASSERT(strstr(log, "resynced 10 times in 9s: net +0ms, absolute 10000ms") != NULL);
+	PASS();
+}
+
+/* A quiet tick on a closed tracker must not log or reopen anything. */
+TEST resync_tick_while_idle_is_silent(void)
+{
+	rad_resync_log_t r = {0};
+
+	cap_begin();
+	for (int i = 0; i < 100; i++)
+		rad_resync_tick(&r, S(4000) + S(i));
+	const char *log = cap_end();
+
+	ASSERT_EQ_FMT(0, (int)strlen(log), "%d");
+	PASS();
+}
+
+SUITE(resync_suite)
+{
+	RUN_TEST(resync_lone_stays_one_line);
+	RUN_TEST(resync_burst_summarised_once);
+	RUN_TEST(resync_long_episode_reports_each_minute);
+	RUN_TEST(resync_tail_after_periodic_report_is_reported);
+	RUN_TEST(resync_alternating_signs_show_in_absolute);
+	RUN_TEST(resync_tick_while_idle_is_silent);
+}


### PR DESCRIPTION
A resync means the SDK lost audio, and the correction is always about the
threshold size, so a sustained loss episode logs the same `150ms` line every
time the error climbs back over it. One observed episode ran to 509 identical
warnings — enough to evict everything else from a 64 KB syslog ring, including
the context needed to explain the episode.

Log the first resync in full, count the rest, and report the episode when it
ends (5 s without one) or once a minute while it continues. The count and the
total correction are the better diagnostic anyway: they say how much audio went
missing and how fast, which a run of identical threshold-sized corrections does
not.

Thresholds and slew behaviour are untouched.

### Verification

- Builds clean for `PLATFORM=T31` with a mipsel/uClibc toolchain.
- 220/220 host tests pass.
- Exercised on hardware by SIGSTOPping rad six times inside the window, which
  makes `MI_AI_GetFrame` report lost buffers — two lines instead of six:

```
audio clock resync +1016ms (lost samples or stall)
audio clock resynced 6 times in 10s, +5976ms corrected in total
```

The cause of the periodicity behind the original 509-warning episode is still
open — 60 s of CPU starvation produces no resyncs at all, since the DMA ring
absorbs scheduling delay. This changes the reporting, not the cause; it is what
makes the next episode legible.