### PR TITLE
rsd: keep audio monotonic and preserve it through queue recovery

### DIFF
--- a/rsd/rsd.h
+++ b/rsd/rsd.h
@@ -66,7 +66,7 @@ typedef struct {
  * waiting for any send thread to finish. The memcpy cost is small
  * next to the send-latency hit we'd otherwise take from a barrier
  * wait, especially on slow single-core SoCs. */
-#define RSD_SENDQ_SLOTS	  8
+#define RSD_SENDQ_SLOTS	  32
 #define RSD_FRAME_VIDEO	  0
 #define RSD_FRAME_AUDIO	  1
 #define RSD_SENDQ_OK	  0
@@ -95,9 +95,11 @@ typedef struct {
 	 * Discard accounting. One queue carries both streams, audio pushes at
 	 * 50/s against video's 30/s, and a single video entry can hold the send
 	 * thread for the length of an IDR's worth of blocking writes -- so
-	 * RSD_SENDQ_SLOTS is only about 100ms of stream and a slow client
-	 * overflows it. Without these counters an overflow is indistinguishable
-	 * from a capture fault, which is exactly the confusion that cost a
+	 * RSD_SENDQ_SLOTS is about 400ms of a 25fps video plus AAC stream. This
+	 * absorbs ordinary Wi-Fi scheduling stalls without growing the queue far
+	 * enough to hide a genuinely slow client. Without these counters an
+	 * overflow is indistinguishable from a capture fault, which is exactly
+	 * the confusion that cost a
 	 * round of board testing on the audio dropouts.
 	 */
 	uint32_t drop_audio; /* audio entries discarded to overflow */

--- a/rsd/rsd.h
+++ b/rsd/rsd.h
@@ -127,6 +127,8 @@ typedef struct rsd_client {
 	uint32_t audio_ts_offset;
 	uint32_t audio_ts_rand;
 	bool audio_ts_base_set;
+	uint32_t last_audio_client_ts; /* per-client monotonic enforcement */
+	bool has_last_audio_client_ts;
 	bool is_tcp;
 	int stream_idx;	      /* RSD_STREAM_MAIN or RSD_STREAM_SUB */
 	uint32_t video_codec; /* RSS_CODEC_H264 or RSS_CODEC_H265 */

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -556,7 +556,6 @@ void *rsd_video_reader_thread(void *arg)
 					} else {
 						c->waiting_keyframe = true;
 						c->video_ts_base_set = false;
-						c->audio_ts_base_set = false;
 					}
 				}
 			}
@@ -748,7 +747,6 @@ void *rsd_video_reader_thread(void *arg)
 					total_pushed++;
 				else if (qret == RSD_SENDQ_DROPPED) {
 					c->waiting_keyframe = (c->video.jpeg == NULL);
-					c->audio_ts_base_set = false;
 					rsd_maybe_request_idr(rctx->ring, &last_idr_req_us);
 				}
 			}
@@ -1024,6 +1022,11 @@ void *rsd_audio_reader_thread(void *arg)
 					c->audio_ts_base_set = true;
 				}
 				uint32_t client_ts = rtp_ts - c->audio_ts_offset + c->audio_ts_rand;
+				if (c->has_last_audio_client_ts &&
+				    (int32_t)(client_ts - c->last_audio_client_ts) <= 0)
+					client_ts = c->last_audio_client_ts + frame_samples;
+				c->last_audio_client_ts = client_ts;
+				c->has_last_audio_client_ts = true;
 				rsd_sendq_push_audio(&c->sendq, audio_codec, audio_buf, length,
 						     client_ts);
 			}

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -135,21 +135,38 @@ void rsd_sendq_destroy(rsd_sendq_t *q)
 	pthread_mutex_destroy(&q->lock);
 }
 
-/* Only reached from the video overflow path, so the discards are accounted
- * here rather than at the call site. */
-static void sendq_flush_locked(rsd_sendq_t *q)
+/*
+ * Drop queued video after the client falls behind, but retain audio. The
+ * caller will hold video at the next keyframe; keeping independently
+ * decodable audio here avoids turning the video recovery into a sound gap.
+ * Caller holds q->lock.
+ */
+static void sendq_drop_video_locked(rsd_sendq_t *q)
 {
+	rsd_sendq_entry_t audio[RSD_SENDQ_SLOTS];
+	int audio_count = 0;
+
 	while (q->count > 0) {
-		if (q->entries[q->tail].type == RSD_FRAME_AUDIO)
-			q->drop_audio++;
-		else
-			q->drop_video++;
-		sendq_release_entry(&q->entries[q->tail]);
+		rsd_sendq_entry_t entry = q->entries[q->tail];
+		q->entries[q->tail].data = NULL;
 		q->tail = (q->tail + 1) % RSD_SENDQ_SLOTS;
 		q->count--;
+
+		if (entry.type == RSD_FRAME_AUDIO) {
+			audio[audio_count++] = entry;
+		} else {
+			q->drop_video++;
+			sendq_release_entry(&entry);
+		}
 	}
+
 	q->head = 0;
 	q->tail = 0;
+	for (int i = 0; i < audio_count; i++) {
+		q->entries[q->head] = audio[i];
+		q->head = (q->head + 1) % RSD_SENDQ_SLOTS;
+		q->count++;
+	}
 }
 
 /*
@@ -246,11 +263,13 @@ static int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t le
 		return -1;
 	}
 
-	bool dropped = false;
 	if (q->count >= RSD_SENDQ_SLOTS) {
 		q->overflows++;
-		sendq_flush_locked(q);
-		dropped = true;
+		sendq_drop_video_locked(q);
+		q->drop_video++; /* incoming pre-keyframe frame */
+		pthread_mutex_unlock(&q->lock);
+		free(copy);
+		return RSD_SENDQ_DROPPED;
 	}
 
 	rsd_sendq_entry_t *slot = &q->entries[q->head];
@@ -265,7 +284,7 @@ static int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t le
 
 	pthread_cond_signal(&q->cond);
 	pthread_mutex_unlock(&q->lock);
-	return dropped ? RSD_SENDQ_DROPPED : RSD_SENDQ_OK;
+	return RSD_SENDQ_OK;
 }
 
 static int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *data, uint32_t len,
@@ -288,7 +307,7 @@ static int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *d
 	 * policy -- a decoder that has lost frames wants the next IDR, not the
 	 * frames in between -- and the wrong one for audio, where every chunk
 	 * is independently useful: it discards up to RSD_SENDQ_SLOTS entries,
-	 * a ~100ms hole in the sound, to make room for 20ms of it. Worse, it
+	 * a noticeable hole in the sound, to make room for 20ms of it. Worse, it
 	 * takes the queued video with it.
 	 *
 	 * Drop the oldest audio chunk instead. That bounds the loss at one
@@ -308,7 +327,7 @@ static int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *d
 			free(copy);
 			return RSD_SENDQ_DROPPED;
 		}
-		/* Freed under the lock, as sendq_flush_locked does: releasing it
+		/* Freed under the lock, as sendq_drop_video_locked does: releasing it
 		 * to free() would let another push refill the queue before the
 		 * slot below is written. */
 		sendq_release_entry(&victim);


### PR DESCRIPTION
## Summary

- keep the audio RTP base intact during video ring and send-queue recovery
- add a lifetime per-client monotonic guard for audio, mirroring video
- grow the bounded mixed-media send queue from 8 to 32 entries
- on video overflow, discard/rekey video while retaining queued audio

## Causes

Video recovery cleared `audio_ts_base_set`. The next audio frame then rebased to
`audio_ts_rand` even though the send thread or TCP socket could still contain
later packets. On a T41 camera this produced observed jumps from 15.188 s to
0.468 s and from 59.892 s to 16.054 s.

After fixing the rebase, the eight-entry queue still represented only about
110 ms at 25 fps plus AAC. Ordinary transient client stalls filled it. A video
push then flushed both tracks, turning video recovery into an audible dropout.

Video recovery does not restart the audio clock, and AAC frames remain
independently useful. The new policy keeps audio queued while video waits for
the next keyframe. The 32-entry bound adds roughly 445 ms of burst tolerance
without allowing an indefinitely slow client to accumulate latency.

## Verification

- T41 uClibc cross-build with `-Wall -Wextra -Werror`
- RSD x86 ASan/UBSan build
- 232 host unit tests passed (1,205 assertions)
- raw interleaved-RTP test under logged overflow: zero reordered packets and
  zero backward timestamps on both tracks
- T41 Wyze Cam 4 A/B with LightNVR plus a local RTSP/TCP verifier:
  - before queue policy fix: 120 s had a 512 ms audio gap and RSD reported 47
    audio / 22 video queue discards
  - after fix: 120.025 s, 2,999 video packets and 5,625 AAC packets, zero
    non-increasing timestamps, zero video gaps, zero audio gaps
- final audio was AAC-LC, 48 kHz mono; peak level was -5.4 dBFS with no clipping
