### PR TITLE
rsd: anchor RTCP reports to the RTP media clock

### DIFF
--- a/rsd/rsd_media_clock.h
+++ b/rsd/rsd_media_clock.h
@@ -1,0 +1,53 @@
+/*
+ * rsd_media_clock.h -- map a 32-bit RTP timeline to CLOCK_MONOTONIC
+ *
+ * Header-only so the queue/unit harness can pin the clock behavior without
+ * pulling in the RTSP server or Compy.
+ */
+
+#ifndef RSD_MEDIA_CLOCK_H
+#define RSD_MEDIA_CLOCK_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct {
+	uint64_t base_us;
+	uint64_t elapsed_ticks;
+	uint32_t last_rtp_ts;
+	bool initialized;
+} rsd_media_clock_t;
+
+static inline void rsd_media_clock_reset(rsd_media_clock_t *clock)
+{
+	memset(clock, 0, sizeof(*clock));
+}
+
+/*
+ * Advance the media clock from the actual RTP delta. The unsigned subtraction
+ * extends the 32-bit RTP timestamp through wrap. `sample_us` anchors the first
+ * timestamp and is also the safe fallback for a malformed zero clock rate.
+ */
+static inline uint64_t rsd_media_clock_update(rsd_media_clock_t *clock, uint32_t rtp_ts,
+					      uint32_t clock_rate, uint64_t sample_us)
+{
+	if (!clock->initialized) {
+		clock->base_us = sample_us;
+		clock->elapsed_ticks = 0;
+		clock->initialized = true;
+	} else {
+		clock->elapsed_ticks += (uint32_t)(rtp_ts - clock->last_rtp_ts);
+	}
+	clock->last_rtp_ts = rtp_ts;
+
+	if (clock_rate == 0)
+		return sample_us;
+
+	/* Split quotient and remainder so a multi-year session cannot overflow
+	 * elapsed_ticks * 1,000,000 before the division. */
+	return clock->base_us + clock->elapsed_ticks / clock_rate * 1000000 +
+	       clock->elapsed_ticks % clock_rate * 1000000 / clock_rate;
+}
+
+#endif /* RSD_MEDIA_CLOCK_H */

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -13,12 +13,13 @@
 #include <pthread.h>
 
 #include "rsd.h"
+#include "rsd_media_clock.h"
 
 /* Forward declarations — called by send thread, defined below */
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
-				 uint32_t rtp_ts);
+				 uint32_t rtp_ts, uint64_t clock_us);
 static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				uint32_t rtp_ts);
+				uint32_t rtp_ts, uint64_t clock_us);
 
 /*
  * Minimum interval between IDR requests from the reader's lag-recovery
@@ -118,7 +119,8 @@ static void sendq_drain_audio(rsd_client_t *c)
 
 	if (got) {
 		pthread_mutex_lock(&c->write_lock);
-		rsd_send_audio_frame(c, audio.codec, audio.data, audio.len, audio.rtp_ts);
+		rsd_send_audio_frame(c, audio.codec, audio.data, audio.len, audio.rtp_ts,
+				     audio.clock_us);
 		pthread_mutex_unlock(&c->write_lock);
 		rsd_sendq_release_entry(&audio);
 	}
@@ -130,7 +132,7 @@ static void sendq_drain_audio(rsd_client_t *c)
  * large IDR frames from starving audio delivery.
  */
 static void rsd_send_video_interleaved(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				       uint32_t rtp_ts)
+				       uint32_t rtp_ts, uint64_t clock_us)
 {
 	if (!c->video.nal || !c->video.playing)
 		return;
@@ -193,6 +195,9 @@ static void rsd_send_video_interleaved(rsd_client_t *c, const uint8_t *data, uin
 			sendq_drain_audio(c);
 	}
 
+	if (nalu_count > 0)
+		Compy_RtpTransport_set_clock_reference(c->video.rtp, rtp_ts, clock_us);
+
 	if (c->srv->rtcp_sr) {
 		int64_t now = rss_timestamp_us();
 		if (c->video.rtcp && now - c->video.last_rtcp > RSD_SR_INTERVAL_US) {
@@ -228,12 +233,15 @@ void *rsd_client_send_thread(void *arg)
 
 		if (entry.type == RSD_FRAME_VIDEO) {
 			if (c->video.jpeg)
-				rsd_send_jpeg_frame(c, entry.data, entry.len, entry.rtp_ts);
+				rsd_send_jpeg_frame(c, entry.data, entry.len, entry.rtp_ts,
+						    entry.clock_us);
 			else
-				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts);
+				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts,
+						   entry.clock_us);
 		} else {
 			pthread_mutex_lock(&c->write_lock);
-			rsd_send_audio_frame(c, entry.codec, entry.data, entry.len, entry.rtp_ts);
+			rsd_send_audio_frame(c, entry.codec, entry.data, entry.len, entry.rtp_ts,
+					     entry.clock_us);
 			pthread_mutex_unlock(&c->write_lock);
 		}
 
@@ -255,6 +263,7 @@ void *rsd_video_reader_thread(void *arg)
 	int64_t video_ts_epoch = 0;
 	uint32_t last_rtp_ts = 0; /* enforce monotonic RTP timestamps */
 	bool has_last_rtp_ts = false;
+	rsd_media_clock_t video_media_clock = { 0 };
 	uint64_t last_write_seq = 0;
 	int idle_count = 0;
 
@@ -298,6 +307,7 @@ void *rsd_video_reader_thread(void *arg)
 			video_ts_epoch = 0;
 			last_rtp_ts = 0;
 			has_last_rtp_ts = false;
+			rsd_media_clock_reset(&video_media_clock);
 			atomic_store_explicit(&rctx->vps_len, 0, memory_order_relaxed);
 			atomic_store_explicit(&rctx->sps_len, 0, memory_order_relaxed);
 			atomic_store_explicit(&rctx->pps_len, 0, memory_order_relaxed);
@@ -455,6 +465,8 @@ void *rsd_video_reader_thread(void *arg)
 
 			if (has_last_rtp_ts && (int32_t)(rtp_ts - last_rtp_ts) <= 0)
 				rtp_ts = last_rtp_ts + frame_dur;
+			uint64_t media_clock_us =
+				rsd_media_clock_update(&video_media_clock, rtp_ts, 90000, meta.timestamp);
 			last_rtp_ts = rtp_ts;
 			has_last_rtp_ts = true;
 
@@ -516,7 +528,8 @@ void *rsd_video_reader_thread(void *arg)
 
 				int qret;
 				qret = rsd_sendq_push_video(&c->sendq, frame_data, length,
-							    client_ts, sei, sei_len, is_h265);
+							    client_ts, media_clock_us, sei, sei_len,
+							    is_h265);
 				if (qret == RSD_SENDQ_OK)
 					total_pushed++;
 				else if (qret == RSD_SENDQ_DROPPED) {
@@ -543,7 +556,8 @@ void *rsd_video_reader_thread(void *arg)
 
 /* ── JPEG send path (RFC 2435) ── */
 
-static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts)
+static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+				uint64_t clock_us)
 {
 	if (!c->video.jpeg || !c->video.playing)
 		return;
@@ -551,6 +565,7 @@ static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t l
 	pthread_mutex_lock(&c->write_lock);
 	(void)!Compy_JpegTransport_send_frame(c->video.jpeg, Compy_RtpTimestamp_Raw(rtp_ts),
 					      U8Slice99_new((uint8_t *)data, len));
+	Compy_RtpTransport_set_clock_reference(c->video.rtp, rtp_ts, clock_us);
 	pthread_mutex_unlock(&c->write_lock);
 
 	if (c->srv->rtcp_sr) {
@@ -567,7 +582,7 @@ static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t l
 /* ── Audio ring reader thread ── */
 
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
-				 uint32_t rtp_ts)
+				 uint32_t rtp_ts, uint64_t clock_us)
 {
 	if (!c->audio.rtp || !c->audio.playing)
 		return;
@@ -595,8 +610,10 @@ static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t 
 		marker = true;
 	}
 
-	(void)!Compy_RtpTransport_send_packet(c->audio.rtp, Compy_RtpTimestamp_Raw(rtp_ts), marker,
-					      payload_hdr, U8Slice99_new((uint8_t *)data, len));
+	int ret = Compy_RtpTransport_send_packet(c->audio.rtp, Compy_RtpTimestamp_Raw(rtp_ts), marker,
+					 payload_hdr, U8Slice99_new((uint8_t *)data, len));
+	if (ret != -1)
+		Compy_RtpTransport_set_clock_reference(c->audio.rtp, rtp_ts, clock_us);
 
 	if (c->srv->rtcp_sr) {
 		int64_t now = rss_timestamp_us();
@@ -619,6 +636,7 @@ void *rsd_audio_reader_thread(void *arg)
 	int64_t audio_ts_epoch = 0;
 	uint32_t last_audio_rtp_ts = 0;
 	bool has_last_audio_rtp_ts = false;
+	rsd_media_clock_t audio_media_clock = { 0 };
 	uint64_t last_write_seq = 0;
 	int idle_count = 0;
 	int64_t last_drop_report = rss_timestamp_us();
@@ -655,6 +673,7 @@ void *rsd_audio_reader_thread(void *arg)
 			audio_ts_epoch = 0;
 			last_audio_rtp_ts = 0;
 			has_last_audio_rtp_ts = false;
+			rsd_media_clock_reset(&audio_media_clock);
 			last_write_seq = 0;
 			idle_count = 0;
 
@@ -776,6 +795,15 @@ void *rsd_audio_reader_thread(void *arg)
 					rtp_ts -= nudge;
 				}
 			}
+			/* RTCP needs the sampling instant corresponding to this exact
+			 * RTP timestamp. AAC output is produced from 20ms capture chunks
+			 * but advances in 1024-sample access units, so meta.timestamp is
+			 * deliberately quantized at a different cadence. Advance a
+			 * continuous media clock from the RTP deltas instead; the 64-bit
+			 * accumulator also stays continuous through 32-bit RTP wrap. */
+			uint64_t media_clock_us = rsd_media_clock_update(
+				&audio_media_clock, rtp_ts, rtp_clock, meta.timestamp);
+
 			last_audio_rtp_ts = rtp_ts;
 			has_last_audio_rtp_ts = true;
 
@@ -802,7 +830,7 @@ void *rsd_audio_reader_thread(void *arg)
 				c->last_audio_client_ts = client_ts;
 				c->has_last_audio_client_ts = true;
 				rsd_sendq_push_audio(&c->sendq, audio_codec, audio_buf, length,
-						     client_ts);
+						     client_ts, media_clock_us);
 			}
 			pthread_mutex_unlock(&srv->clients_lock);
 		}

--- a/rsd/rsd_sendq.c
+++ b/rsd/rsd_sendq.c
@@ -149,7 +149,7 @@ static uint32_t first_vcl_offset(const uint8_t *data, uint32_t len, bool is_h265
  * before the first VCL NAL, after any in-band SPS/PPS.
  */
 int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-			 const uint8_t *sei, uint32_t sei_len, bool is_h265)
+			 uint64_t clock_us, const uint8_t *sei, uint32_t sei_len, bool is_h265)
 {
 	uint8_t *copy = malloc((size_t)len + sei_len);
 	if (!copy)
@@ -184,6 +184,7 @@ int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint
 	slot->data = copy;
 	slot->len = len;
 	slot->rtp_ts = rtp_ts;
+	slot->clock_us = clock_us;
 	slot->type = RSD_FRAME_VIDEO;
 	slot->codec = 0;
 
@@ -196,7 +197,7 @@ int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint
 }
 
 int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *data, uint32_t len,
-			 uint32_t rtp_ts)
+			 uint32_t rtp_ts, uint64_t clock_us)
 {
 	uint8_t *copy = malloc(len);
 	if (!copy)
@@ -245,6 +246,7 @@ int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *data, ui
 	slot->data = copy;
 	slot->len = len;
 	slot->rtp_ts = rtp_ts;
+	slot->clock_us = clock_us;
 	slot->type = RSD_FRAME_AUDIO;
 	slot->codec = codec;
 	slot->zerocopy = false; /* unused, kept for ABI compat */

--- a/rsd/rsd_sendq.h
+++ b/rsd/rsd_sendq.h
@@ -28,6 +28,7 @@ typedef struct {
 	const uint8_t *data; /* malloc'd copy or rmem pointer (zerocopy) */
 	uint32_t len;
 	uint32_t rtp_ts;
+	uint64_t clock_us; /* CLOCK_MONOTONIC media sampling instant */
 	uint8_t type;	  /* RSD_FRAME_VIDEO or RSD_FRAME_AUDIO */
 	uint32_t codec;	  /* audio codec (RSD_FRAME_AUDIO only) */
 	bool zerocopy;	  /* true = rmem pointer, don't free */
@@ -65,8 +66,8 @@ void rsd_sendq_release_entry(rsd_sendq_entry_t *e);
 /* Caller holds q->lock. */
 bool rsd_sendq_take_audio_locked(rsd_sendq_t *q, rsd_sendq_entry_t *out);
 int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-			 const uint8_t *sei, uint32_t sei_len, bool is_h265);
+			 uint64_t clock_us, const uint8_t *sei, uint32_t sei_len, bool is_h265);
 int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *data, uint32_t len,
-			 uint32_t rtp_ts);
+			 uint32_t rtp_ts, uint64_t clock_us);
 
 #endif /* RSD_SENDQ_H */

--- a/tests/test_sendq.c
+++ b/tests/test_sendq.c
@@ -13,18 +13,20 @@
 #include <string.h>
 
 #include "greatest.h"
+#include "../rsd/rsd_media_clock.h"
 #include "../rsd/rsd_sendq.h"
 
 static uint8_t payload[16] = { 0xaa, 0xbb, 0xcc, 0xdd };
 
 static int push_a(rsd_sendq_t *q, uint32_t ts)
 {
-	return rsd_sendq_push_audio(q, 8, payload, sizeof(payload), ts);
+	return rsd_sendq_push_audio(q, 8, payload, sizeof(payload), ts, 1000000u + ts);
 }
 
 static int push_v(rsd_sendq_t *q, uint32_t ts)
 {
-	return rsd_sendq_push_video(q, payload, sizeof(payload), ts, NULL, 0, false);
+	return rsd_sendq_push_video(q, payload, sizeof(payload), ts, 1000000u + ts, NULL, 0,
+				    false);
 }
 
 /* Walk the queue oldest-first, collecting (type, ts) into arrays. */
@@ -55,6 +57,7 @@ TEST push_pop_order_preserved(void)
 	ASSERT_EQ(4, snapshot(&q, types, ts, 8));
 	ASSERT_EQ(RSD_FRAME_VIDEO, types[0]);
 	ASSERT_EQ(100u, ts[0]);
+	ASSERT_EQ(1000100u, q.entries[q.tail].clock_us);
 	ASSERT_EQ(RSD_FRAME_AUDIO, types[1]);
 	ASSERT_EQ(101u, ts[1]);
 	ASSERT_EQ(RSD_FRAME_VIDEO, types[2]);
@@ -229,11 +232,13 @@ TEST sei_spliced_before_first_vcl(void)
 	static const uint8_t sei[] = { 0, 0, 0, 1, 0x06, 0x05, 0x02, 0xde, 0xad };
 
 	ASSERT_EQ(RSD_SENDQ_OK,
-		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, sei, sizeof(sei), false));
+		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, 1234567, sei, sizeof(sei),
+				   false));
 	ASSERT_EQ(1, q.count);
 
 	const rsd_sendq_entry_t *e = &q.entries[q.tail];
 	ASSERT_EQ(sizeof(frame) + sizeof(sei), e->len);
+	ASSERT_EQ(1234567, e->clock_us);
 	/* SPS first (start code + 2 bytes), then the SEI, then the IDR. */
 	ASSERT_EQ(0, memcmp(e->data, frame, 6));
 	ASSERT_EQ(0, memcmp(e->data + 6, sei, sizeof(sei)));
@@ -268,6 +273,32 @@ TEST destroy_frees_pending_entries(void)
 	PASS();
 }
 
+TEST media_clock_follows_rtp_not_aac_chunk_phase(void)
+{
+	rsd_media_clock_t clock = { 0 };
+	const uint64_t base = 10000000;
+
+	ASSERT_EQ(base, rsd_media_clock_update(&clock, 5000, 48000, base));
+	/* AAC is fed by 20ms chunks but each access unit is 1024 samples. The
+	 * media reference must advance by 21.333ms, not by the ring phase. */
+	ASSERT_EQ(base + 21333,
+		  rsd_media_clock_update(&clock, 6024, 48000, base + 20000));
+	ASSERT_EQ(base + 42666,
+		  rsd_media_clock_update(&clock, 7048, 48000, base + 40000));
+	PASS();
+}
+
+TEST media_clock_extends_rtp_wrap(void)
+{
+	rsd_media_clock_t clock = { 0 };
+	const uint64_t base = 20000000;
+
+	ASSERT_EQ(base, rsd_media_clock_update(&clock, 0xfffffc00u, 48000, base));
+	ASSERT_EQ(base + 42666,
+		  rsd_media_clock_update(&clock, 0x00000400u, 48000, base + 42666));
+	PASS();
+}
+
 SUITE(sendq_suite)
 {
 	RUN_TEST(push_pop_order_preserved);
@@ -279,4 +310,6 @@ SUITE(sendq_suite)
 	RUN_TEST(sei_spliced_before_first_vcl);
 	RUN_TEST(shutdown_rejects_pushes);
 	RUN_TEST(destroy_frees_pending_entries);
+	RUN_TEST(media_clock_follows_rtp_not_aac_chunk_phase);
+	RUN_TEST(media_clock_extends_rtp_wrap);
 }


### PR DESCRIPTION
## Summary

- carry the media sampling instant through each per-client send-queue entry
- maintain a continuous 64-bit media clock from the actual 32-bit RTP deltas
- provide the corresponding RTP/media-clock pair to Compy after a successful send
- cover AAC 20 ms input vs. 1024-sample output cadence and RTP wrap

Depends on gtxaspec/compy#1.

## Root cause

AAC is fed by 20 ms capture chunks but each 48 kHz AAC access unit advances RTP by 1024 samples (21.333 ms). RSD correctly sends a smooth RTP timeline, while RTCP previously extrapolated from network send time. FFmpeg then adjusted audio PTS at every sender report.

This is not a packet-loss/Wi-Fi symptom: the matched T41 RTSP/TCP tests had zero sequence gaps on both tracks, video on the same TCP connection stayed clean, and the audio anomalies occurred exactly on the one-second first SR and five-second periodic SR cadence. Latest upstream produced 11 recurring audio PTS discontinuities in 60 seconds (8-10 or 30-32 ms instead of the normal 21-22 ms). With this change, there were zero recurring discontinuities and SR clock error dropped from up to 12.194 ms to 0.015 ms.

## Tests

- Raptor ASan/UBSan suite: 243/243 tests passed, 1461 assertions (one pre-existing unrelated `rmr_mux.c` signed-shift UBSan warning)
- new tests pin AAC cadence mapping and 32-bit RTP wrap
- Compy ASan suite: 131/131 passed
- cross-built for Ingenic T41/uClibc
- raw 35 s RTSP interleaved probe: 0 video/audio sequence gaps; video SR max error 0.005 ms; audio max error 0.015 ms
- 60 s FFmpeg copy recording with `rtcp_sr=true`: no recurring audio or video PTS anomalies