### PR TITLE
rsd: drop clients whose SDP no longer describes what they receive

### DIFF
--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -104,6 +104,43 @@ static void rsd_cache_params(rsd_ring_ctx_t *rctx, const uint8_t *data, uint32_t
 	}
 }
 
+static const char *rsd_codec_name(uint32_t codec)
+{
+	switch (codec) {
+	case 0:
+		return "H.264";
+	case 1:
+		return "H.265";
+	default:
+		return "JPEG";
+	}
+}
+
+/*
+ * Drop every playing client on a stream whose SDP has stopped being true.
+ *
+ * Codec and picture size are both answered in the SDP — sprop-parameter-sets
+ * carries the SPS, and the SPS carries the dimensions — and RTSP has no way to
+ * renegotiate that mid-session. A client left in place is told 2560x1920 while
+ * being sent 1280x720: some players re-read the in-band SPS and recover, others
+ * show corruption or freeze, and a recorder writes a file that disagrees with
+ * its own header. Disconnecting makes the client re-DESCRIBE, which is the only
+ * transition RTSP actually defines.
+ */
+static void rsd_drop_stream_clients(rsd_server_t *srv, int stream_idx, const char *what)
+{
+	pthread_mutex_lock(&srv->clients_lock);
+	for (int i = 0; i < srv->client_count; i++) {
+		rsd_client_t *c = srv->clients[i];
+		if (c && c->stream_idx == stream_idx && c->video.playing) {
+			shutdown(c->fd, SHUT_RDWR);
+			RSS_INFO("disconnecting client on stream %d (%s changed)", stream_idx,
+				 what);
+		}
+	}
+	pthread_mutex_unlock(&srv->clients_lock);
+}
+
 /* Try to pop and send one audio entry from the sendq.
  * Called between video NALUs to interleave audio with large IDR frames. */
 static void sendq_drain_audio(rsd_client_t *c)
@@ -307,7 +344,11 @@ void *rsd_video_reader_thread(void *arg)
 			/* Cache all SDP-relevant fields so the session thread
 			 * never needs to dereference the ring pointer. */
 			const rss_ring_header_t *new_hdr = rss_ring_get_header(rctx->ring);
+			/* Both comparisons read what the old ring advertised, so
+			 * they have to happen before the cache is overwritten. */
 			bool codec_changed = (new_hdr->codec != rctx->last_codec);
+			bool geometry_changed = (new_hdr->width != rctx->last_width ||
+						 new_hdr->height != rctx->last_height);
 			rctx->last_codec = new_hdr->codec;
 			rctx->last_width = new_hdr->width;
 			rctx->last_height = new_hdr->height;
@@ -317,28 +358,32 @@ void *rsd_video_reader_thread(void *arg)
 			rctx->last_level = new_hdr->level;
 
 			/* Ring reconnected — reset all clients on this stream
-			 * so they re-sync from the next keyframe. If codec changed,
-			 * disconnect existing clients (RTSP can't renegotiate SDP
-			 * mid-session — clients must reconnect for new codec). */
-			pthread_mutex_lock(&srv->clients_lock);
-			for (int i = 0; i < srv->client_count; i++) {
-				rsd_client_t *c = srv->clients[i];
-				if (c && c->stream_idx == stream_idx && c->video.playing) {
-					if (codec_changed) {
-						shutdown(c->fd, SHUT_RDWR);
-						RSS_INFO("disconnecting client on stream %d (codec "
-							 "changed)",
-							 stream_idx);
-					} else {
+			 * so they re-sync from the next keyframe, unless what the
+			 * SDP promised them has changed, in which case they are
+			 * dropped instead (see rsd_drop_stream_clients).
+			 *
+			 * A client can only be playing video if last_width was
+			 * already nonzero -- SETUP refuses the stream otherwise
+			 * (rsd_session.c) -- so the first open of a ring cannot
+			 * disconnect anyone through the 0 -> real transition. */
+			if (codec_changed || geometry_changed) {
+				rsd_drop_stream_clients(srv, stream_idx,
+							codec_changed ? "codec" : "resolution");
+			} else {
+				pthread_mutex_lock(&srv->clients_lock);
+				for (int i = 0; i < srv->client_count; i++) {
+					rsd_client_t *c = srv->clients[i];
+					if (c && c->stream_idx == stream_idx && c->video.playing) {
 						c->waiting_keyframe = true;
 						c->video_ts_base_set = false;
 					}
 				}
+				pthread_mutex_unlock(&srv->clients_lock);
 			}
-			pthread_mutex_unlock(&srv->clients_lock);
 
-			RSS_INFO("video reader[%d] reconnected (%s%s)", stream_idx, rctx->ring_name,
-				 codec_changed ? ", codec changed" : "");
+			RSS_INFO("video reader[%d] reconnected (%s%s%s)", stream_idx,
+				 rctx->ring_name, codec_changed ? ", codec changed" : "",
+				 geometry_changed ? ", resolution changed" : "");
 		}
 
 		int ret = rss_ring_wait(rctx->ring, 100);
@@ -412,19 +457,49 @@ void *rsd_video_reader_thread(void *arg)
 		uint32_t frame_dur = 90000 / fps;
 
 		/*
-		 * The session thread builds a=framerate from the cache below, and
-		 * a rate change reaches the header in place -- the ring is not
-		 * reopened and nobody is woken -- so the reconnect path above
-		 * never sees it. Refresh it here, where the header is already in
-		 * hand for the pacing above. Rate only: a codec or geometry
-		 * change has to reset clients, which stays the reconnect path's
-		 * job.
+		 * The session thread builds the SDP from the cache below, and a
+		 * reconfigure reaches the header in place -- rvd reuses the ring
+		 * across an encoder restart and rewrites its stream info
+		 * (rvd_pipeline.c), so nothing is closed, nothing is reopened,
+		 * and the reconnect path above never runs. Refresh here, where
+		 * the header is already in hand for the pacing above.
+		 *
+		 * Rate is a cache update and nothing more: a=framerate is
+		 * advisory and every client keeps playing. Codec and geometry
+		 * are not -- they are what the SPS in the SDP says, so the
+		 * clients holding the old answer have to go, and the cached
+		 * parameter sets with them: dropping the lengths makes the next
+		 * keyframe re-cache (see the sps_len test in the read loop),
+		 * which is what a re-DESCRIBE will then be answered with.
 		 */
 		if (rhdr->fps_num != rctx->last_fps_num || rhdr->fps_den != rctx->last_fps_den) {
 			RSS_INFO("ring[%d]: rate now %u/%u fps", rctx->idx, rhdr->fps_num,
 				 rhdr->fps_den);
 			rctx->last_fps_num = rhdr->fps_num;
 			rctx->last_fps_den = rhdr->fps_den;
+		}
+
+		if (rhdr->codec != rctx->last_codec || rhdr->width != rctx->last_width ||
+		    rhdr->height != rctx->last_height) {
+			bool codec_changed = (rhdr->codec != rctx->last_codec);
+
+			RSS_INFO("ring[%d]: stream is now %s %ux%u (was %s %ux%u)", rctx->idx,
+				 rsd_codec_name(rhdr->codec), rhdr->width, rhdr->height,
+				 rsd_codec_name(rctx->last_codec), (unsigned)rctx->last_width,
+				 (unsigned)rctx->last_height);
+
+			rctx->last_codec = rhdr->codec;
+			rctx->last_width = rhdr->width;
+			rctx->last_height = rhdr->height;
+			rctx->last_profile = rhdr->profile;
+			rctx->last_level = rhdr->level;
+
+			atomic_store_explicit(&rctx->vps_len, 0, memory_order_relaxed);
+			atomic_store_explicit(&rctx->sps_len, 0, memory_order_relaxed);
+			atomic_store_explicit(&rctx->pps_len, 0, memory_order_relaxed);
+
+			rsd_drop_stream_clients(srv, stream_idx,
+						codec_changed ? "codec" : "resolution");
 		}
 
 		for (int burst = 0; burst < 8; burst++) {

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -1915,6 +1915,125 @@ if [ "$KEEP" = "1" ]; then
     wait
 fi
 
+# ── A geometry change drops the clients holding the old SDP ──
+# The picture size is answered in the SDP -- the SPS rides in
+# sprop-parameter-sets and carries the dimensions -- and RTSP cannot
+# renegotiate it mid-session, so a client left in place is told one size
+# while being sent another. rvd reuses the ring across an encoder restart
+# and rewrites its stream info in place: nothing is closed, nothing is
+# reopened, and no reconnect event carries the news, so the reader has to
+# see it on the live header. A rate change in the same session is the
+# control: a framerate is advisory, and refreshing it must disconnect
+# nobody. Runs late, beside the recovery legs, because set-resolution
+# rebuilds the encoder and the legs above are entitled to a stream that
+# has not been restarted under them.
+GEO_OUT=$(python3 - "$OUT/raptorctl" <<'GEO_EOF'
+import socket, subprocess, sys, time
+
+def req(sock, buf, method, url, cseq, extra=""):
+    sock.sendall(f"{method} {url} RTSP/1.0\r\nCSeq: {cseq}\r\n{extra}\r\n".encode())
+    while b"\r\n\r\n" not in buf[0]:
+        d = sock.recv(4096)
+        if not d:
+            return ""
+        buf[0] += d
+    head, _, rest = buf[0].partition(b"\r\n\r\n")
+    headers = head.decode(errors="replace")
+    clen = 0
+    for line in headers.split("\r\n"):
+        if line.lower().startswith("content-length:"):
+            clen = int(line.split(":", 1)[1])
+    while len(rest) < clen:
+        rest += sock.recv(4096)
+    buf[0] = rest[clen:]
+    return headers
+
+def ctl(*args):
+    r = subprocess.run([sys.argv[1]] + list(args), capture_output=True,
+                       text=True, timeout=20)
+    return r.stdout
+
+def media(sock, seconds):
+    """Interleaved bytes read inside the window, or None once the server closes."""
+    end = time.time() + seconds
+    got = 0
+    while True:
+        left = end - time.time()
+        if left <= 0:
+            return got
+        sock.settimeout(left)
+        try:
+            d = sock.recv(65536)
+        except socket.timeout:
+            return got
+        if not d:
+            return None
+        got += len(d)
+
+base = "rtsp://127.0.0.1:15554/stream0"
+s = socket.create_connection(("127.0.0.1", 15554), timeout=5)
+buf = [b""]
+req(s, buf, "DESCRIBE", base, 1, "Accept: application/sdp\r\n")
+setup = req(s, buf, "SETUP", base + "/video", 2,
+            "Transport: RTP/AVP/TCP;unicast;interleaved=0-1\r\n")
+sid = ""
+for line in setup.split("\r\n"):
+    if line.lower().startswith("session:"):
+        sid = line.split(":", 1)[1].split(";")[0].strip()
+sess = f"Session: {sid}\r\n"
+play = req(s, buf, "PLAY", base, 3, sess + "Range: npt=0.000-\r\n")
+if " 200 " not in play.split("\r\n")[0] + " ":
+    print("PLAY_FAILED")
+    sys.exit(0)
+if not media(s, 3.0):
+    print("NO_MEDIA")
+    sys.exit(0)
+
+# Control: the rate is a cache refresh, and every client plays on.
+ctl("rvd", "set-fps", "0", "12")
+print("FPS_KEPT=" + ("1" if media(s, 3.0) else "0"))
+ctl("rvd", "set-fps", "0", "25")
+
+res = ctl("rvd", "set-resolution", "0", "1280", "720")
+print("SETRES_OK=" + ("1" if '"ok"' in res else "0"))
+print("DROPPED=" + ("1" if media(s, 10.0) is None else "0"))
+s.close()
+
+# Hand the following legs back the geometry they had, and prove the
+# server survived the disconnect it just made.
+ctl("rvd", "set-resolution", "0", "1920", "1080")
+time.sleep(2)
+s2 = socket.create_connection(("127.0.0.1", 15554), timeout=5)
+alive = req(s2, [b""], "DESCRIBE", base, 1, "Accept: application/sdp\r\n")
+print("ALIVE=" + ("1" if " 200 " in alive.split("\r\n")[0] + " " else "0"))
+s2.close()
+GEO_EOF
+)
+if echo "$GEO_OUT" | grep -qE "PLAY_FAILED|NO_MEDIA"; then
+    skip "resolution change disconnects the stream's clients" \
+        "no playing session to test ($GEO_OUT)"
+elif echo "$GEO_OUT" | grep -q "SETRES_OK=0"; then
+    skip "resolution change disconnects the stream's clients" "set-resolution was refused"
+else
+    if echo "$GEO_OUT" | grep -q "FPS_KEPT=1"; then
+        pass "a rate change leaves playing clients alone"
+    else
+        fail "a rate change leaves playing clients alone" \
+            "the client stopped receiving after set-fps"
+    fi
+    if echo "$GEO_OUT" | grep -q "DROPPED=1"; then
+        pass "resolution change disconnects the stream's clients"
+    else
+        fail "resolution change disconnects the stream's clients" \
+            "still connected 10s after set-resolution"
+    fi
+    if echo "$GEO_OUT" | grep -q "ALIVE=1"; then
+        pass "rsd answers DESCRIBE after dropping a client"
+    else
+        fail "rsd answers DESCRIBE after dropping a client" "$GEO_OUT"
+    fi
+fi
+
 # ── Recovery invariants: RTP through disturbances ──
 # The slow-client legs above prove the server SURVIVES a stall; this
 # one proves the streams stay CORRECT through it: both tracks' RTP


### PR DESCRIPTION
The codec and the picture size are both answered in the SDP -- the SPS
travels in sprop-parameter-sets, and the SPS carries the dimensions --
and RTSP cannot renegotiate that mid-session. Codec changes already
disconnected for exactly this reason. Resolution changes did not: those
clients kept the SDP they negotiated and were told 2560x1920 while being
sent 1280x720. A player that re-reads the in-band SPS recovers; one that
trusts the SDP shows corruption or freezes, and a recorder writes a file
that disagrees with its own header.

The reconnect path was also the wrong place to look for it. rvd reuses
the ring across an encoder restart and rewrites its stream info in place
(rvd_pipeline.c), so a live set-resolution closes nothing and reopens
nothing, and the reader never sees the ring-replacement event this file
assumed would carry the news -- the fps refresh a few lines up was
already there for the same reason, and said so while explicitly leaving
codec and geometry to a path that does not run.

So both paths handle it now: the reopen case for a producer that really
did restart with new geometry, and the in-place case for a reconfigure
under a live ring. The in-place one also drops the cached parameter sets,
so the next keyframe re-caches them and a re-DESCRIBE is answered with
the SPS that matches what is being sent.

Board-verified on SSC377QE: ffmpeg attached at 2560x1920 gets an EOF at
the moment of the change instead of a silent geometry swap, and the
client that reconnects is told 1280x720. A first ring open cannot drop
anyone through the 0 -> real transition: SETUP refuses a stream whose
last_width is still zero, so nothing can be playing yet.

An integration leg plays a TCP-interleaved session on stream0 and moves
the rate under it first, as the control -- a framerate is advisory and
that client has to keep receiving -- then moves the resolution and
requires the socket to reach EOF, with a DESCRIBE afterwards proving rsd
survived the disconnect it just made. Mutation-checked: taking the
disconnect out of the in-place path leaves the client attached and fails
the resolution leg, and dropping clients on the rate change as well
fails the control. It runs beside the recovery legs at the end, because
set-resolution rebuilds the encoder and every leg above it is entitled
to a stream that has not been restarted underneath it. The reopen path
has no leg of its own -- nothing in the suite restarts a producer with
new geometry, and the restart legs that exist cover only its unchanged
case. Suite goes 139 -> 142, still 0 fail.

rsd-555 has the same gap and is not fixed here. Its subsessions build
sprop-parameter-sets from a cache the reader fills when it opens the
ring (rsd555_reader.c), and the rebuild in rsd555_main.cpp fires once,
on the 0 -> real transition, so a later geometry change reaches neither
the SDP nor the clients holding it. Ending those sessions is live555's
bookkeeping rather than this reader's, and the optional server is owed
that work on its own.

