### PR TITLE
rvd: write a JPEG channel's settings where they are read from

### DIFF
--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -142,6 +142,26 @@ static int rvd_apply_sensor_fps(rvd_state_t *st, uint32_t num, uint32_t den)
 	return 0;
 }
 
+/*
+ * Which config key persists this encoder setting for this stream, or NULL if
+ * this stream has nowhere to write it.
+ *
+ * A JPEG snapshot channel shares its parent video stream's section but not its
+ * keys: what it takes from there is jpeg_-prefixed. The H.26x rate-control keys
+ * have no snapshot counterpart at all, so those changes apply to the running
+ * encoder and are deliberately not written down -- persisting them under the
+ * parent's plain key would retune the video stream at the next boot, from a
+ * command that never mentioned it.
+ */
+static const char *rvd_persist_key(const rvd_stream_t *s, const char *key)
+{
+	if (!s->is_jpeg)
+		return key;
+	if (strcmp(key, "fps") == 0)
+		return "jpeg_fps";
+	return NULL;
+}
+
 /* ── Encoder commands ── */
 
 static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t *st, char *resp,
@@ -207,10 +227,12 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 				bitrate = (uint32_t)br;
 			int ret = RSS_HAL_CALL(st->ops, enc_set_rc_mode, st->hal_ctx,
 					       st->streams[chn].chn, mode, bitrate);
+			const char *key = rvd_persist_key(&st->streams[chn], "rc_mode");
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.rc_mode = mode;
-				rss_config_set_str(st->cfg, st->streams[chn].cfg_sect, "rc_mode",
-						   mode_str);
+				if (key)
+					rss_config_set_str(st->cfg, st->streams[chn].cfg_sect, key,
+							   mode_str);
 			}
 			cJSON *r = cJSON_CreateObject();
 			cJSON_AddStringToObject(r, "status", ret == 0 ? "ok" : "error");
@@ -227,10 +249,12 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 		    chn < st->stream_count) {
 			int ret = RSS_HAL_CALL(st->ops, enc_set_bitrate, st->hal_ctx,
 					       st->streams[chn].chn, val);
+			const char *key = rvd_persist_key(&st->streams[chn], "bitrate");
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.bitrate = val;
-				rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, "bitrate",
-						   val);
+				if (key)
+					rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, key,
+							   val);
 			}
 			return fmt_hal_result(resp, resp_size, ret);
 		}
@@ -243,9 +267,12 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 		    chn < st->stream_count) {
 			int ret = RSS_HAL_CALL(st->ops, enc_set_gop, st->hal_ctx,
 					       st->streams[chn].chn, val);
+			const char *key = rvd_persist_key(&st->streams[chn], "gop");
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.gop_length = val;
-				rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, "gop", val);
+				if (key)
+					rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, key,
+							   val);
 			}
 			return fmt_hal_result(resp, resp_size, ret);
 		}
@@ -258,6 +285,7 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 		    chn < st->stream_count) {
 			int ret = RSS_HAL_CALL(st->ops, enc_set_fps, st->hal_ctx,
 					       st->streams[chn].chn, val, 1);
+			const char *key = rvd_persist_key(&st->streams[chn], "fps");
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.fps_num = val;
 				st->streams[chn].enc_cfg.fps_den = 1;
@@ -265,7 +293,9 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 				 * transient sensor-rate override on this stream. */
 				st->streams[chn].active_fps_num = 0;
 				st->streams[chn].active_fps_den = 0;
-				rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, "fps", val);
+				if (key)
+					rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, key,
+							   val);
 				rvd_stream_publish_info(st, chn);
 			}
 			return fmt_hal_result(resp, resp_size, ret);
@@ -280,13 +310,17 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 		    chn < st->stream_count) {
 			int ret = RSS_HAL_CALL(st->ops, enc_set_qp_bounds, st->hal_ctx,
 					       st->streams[chn].chn, val, val2);
+			const char *min_key = rvd_persist_key(&st->streams[chn], "min_qp");
+			const char *max_key = rvd_persist_key(&st->streams[chn], "max_qp");
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.min_qp = val;
 				st->streams[chn].enc_cfg.max_qp = val2;
-				rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, "min_qp",
-						   val);
-				rss_config_set_int(st->cfg, st->streams[chn].cfg_sect, "max_qp",
-						   val2);
+				if (min_key)
+					rss_config_set_int(st->cfg, st->streams[chn].cfg_sect,
+							   min_key, val);
+				if (max_key)
+					rss_config_set_int(st->cfg, st->streams[chn].cfg_sect,
+							   max_key, val2);
 			}
 			return fmt_hal_result(resp, resp_size, ret);
 		}

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -956,6 +956,15 @@ int rvd_pipeline_init(rvd_state_t *st)
 			st->streams[ji].fs_chn = st->streams[v].fs_chn;
 			st->streams[ji].chn = jpeg_chn;
 			st->streams[ji].sensor_idx = st->streams[v].sensor_idx;
+			/* Snapshot channels have no section of their own: they are
+			 * configured from the parent stream's, under jpeg_-prefixed
+			 * keys (jpeg_quality and jpeg_fps, read just above). Carrying
+			 * that section here is what lets a runtime change be written
+			 * back to the place it was read from -- left empty, a
+			 * persisted key lands sectionless at the top of the file,
+			 * where nothing reads it again. */
+			rss_strlcpy(st->streams[ji].cfg_sect, sect,
+				    sizeof(st->streams[ji].cfg_sect));
 			st->streams[ji].is_jpeg = true;
 			st->streams[ji].jpeg_idle = rss_config_get_bool(cfg, "jpeg", "idle", true);
 			st->streams[ji].enc_cfg.init_qp = quality;

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -909,6 +909,40 @@ else
         "expected 'running config saved' in rvd log"
 fi
 
+# ── A snapshot channel's settings land in a section that is read back ──
+# A JPEG channel is built from its parent video stream and has no
+# section of its own. Given an empty one, a persisted key is written
+# above every [section] header, where no loader will ever read it
+# again -- the file still parses, the daemon still answers ok, and the
+# setting is gone at the next boot. So this goes through the file:
+# set-jpeg-quality is the one command that only accepts a JPEG channel,
+# and the channel index is discovered rather than assumed, since it
+# depends on how many video streams the config declares.
+JQ_CHN=""
+for c in 0 1 2 3 4 5; do
+    if "$OUT/raptorctl" rvd set-jpeg-quality "$c" 60 2>/dev/null | grep -q '"ok"'; then
+        JQ_CHN="$c"
+        break
+    fi
+done
+if [ -z "$JQ_CHN" ]; then
+    skip "jpeg quality persists into a real section" "no JPEG channel accepted set-jpeg-quality"
+else
+    "$OUT/raptorctl" config save > /dev/null 2>&1
+    sleep 1
+    FIRST_SECT=$(grep -n '^\[' "$CONFIG" | head -1 | cut -d: -f1)
+    ORPHANS=$(head -n "$((FIRST_SECT - 1))" "$CONFIG" | grep -c '^[a-z_][a-z_]* *=' || true)
+    if [ "${ORPHANS:-0}" -ne 0 ]; then
+        fail "jpeg quality persists into a real section" \
+            "$ORPHANS key(s) written above the first [section] header"
+    elif sed -n "/^\[stream0\]/,/^\[/p" "$CONFIG" | grep -q '^jpeg_quality *= *60'; then
+        pass "jpeg quality persists into a real section (chn $JQ_CHN -> [stream0])"
+    else
+        fail "jpeg quality persists into a real section" \
+            "jpeg_quality = 60 is not in [stream0]"
+    fi
+fi
+
 echo ""
 echo "=== SRT PSI cadence ==="
 

--- a/tests/test_ctrl.c
+++ b/tests/test_ctrl.c
@@ -362,11 +362,22 @@ static void setup(void)
 	st.streams[1].is_jpeg = false;
 	snprintf(st.streams[1].cfg_sect, sizeof(st.streams[1].cfg_sect), "stream1");
 
-	/* Stream 2: JPEG snapshot channel */
+	/* Stream 2: JPEG snapshot channel, hw channel 2.
+	 *
+	 * Its section is stream0's, not one of its own: a snapshot channel is
+	 * built from its parent video stream and configured out of that
+	 * stream's section under jpeg_-prefixed keys, so that is the section
+	 * rvd_pipeline hands it and the one a runtime change has to write. */
 	st.streams[2].chn = 2;
 	st.streams[2].fs_chn = 0;
+	st.streams[2].enc_cfg.codec = RSS_CODEC_MJPEG;
+	st.streams[2].enc_cfg.width = 1920;
+	st.streams[2].enc_cfg.height = 1080;
+	st.streams[2].enc_cfg.fps_num = 1;
+	st.streams[2].enc_cfg.fps_den = 1;
+	st.streams[2].enc_cfg.init_qp = 75;
 	st.streams[2].is_jpeg = true;
-	snprintf(st.streams[2].cfg_sect, sizeof(st.streams[2].cfg_sect), "jpeg0");
+	snprintf(st.streams[2].cfg_sect, sizeof(st.streams[2].cfg_sect), "stream0");
 
 	/* WB initial state */
 	wb_state =
@@ -483,6 +494,91 @@ TEST set_fps_no_publish_on_hal_failure(void)
 	call("{\"cmd\":\"set-fps\",\"channel\":0,\"value\":60}");
 	ASSERT_EQ(25, (int)st.streams[0].enc_cfg.fps_num);
 	ASSERT_EQ_FMT(0, rec.publish_count, "%d");
+	teardown();
+	PASS();
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ *  A snapshot channel persists into the section it is read from
+ * ══════════════════════════════════════════════════════════════════
+ *
+ * Stream 2 is a JPEG channel carrying stream0's section, which is what
+ * rvd_pipeline gives it -- a snapshot channel is built from its parent
+ * video stream and configured out of that stream's section, under
+ * jpeg_-prefixed keys. It shares the section but not the keys, so each
+ * command either writes the jpeg_ key or writes nothing:
+ *
+ *   command on channel 2      HAL   [stream0] afterwards
+ *   ----------------------    ---   -------------------------------
+ *   set-jpeg-quality 60       yes   jpeg_quality = 60
+ *   set-fps 5                 yes   jpeg_fps = 5, fps untouched
+ *   set-bitrate 4000000       yes   nothing
+ *   set-gop 10                yes   nothing
+ *   set-qp-bounds 10 40       yes   nothing
+ *   set-rc-mode cbr           yes   nothing
+ *
+ * The last four are the rate-control keys, which have no snapshot
+ * counterpart: writing the parent's plain key would retune the video
+ * stream at the next boot from a command that never mentioned it, so
+ * the change applies to the running encoder and stops there. Every one
+ * of those keys is still written for the video streams, which the
+ * mutation legs above pin.
+ */
+
+TEST jpeg_quality_persists_under_the_parent_section(void)
+{
+	setup();
+	rec.return_val = 0;
+	call("{\"cmd\":\"set-jpeg-quality\",\"channel\":2,\"value\":60}");
+	ASSERT_EQ(60, st.streams[2].enc_cfg.init_qp);
+	ASSERT_EQ(60, rss_config_get_int(st.cfg, "stream0", "jpeg_quality", 0));
+	teardown();
+	PASS();
+}
+
+TEST jpeg_fps_persists_under_the_jpeg_key(void)
+{
+	setup();
+	rec.return_val = 0;
+	call("{\"cmd\":\"set-fps\",\"channel\":2,\"value\":5}");
+	/* The encoder was asked, on the JPEG channel's own hw channel... */
+	ASSERT_EQ_FMT(2, rec.last_chn, "%d");
+	ASSERT_EQ_FMT(5u, rec.set_fps_num, "%u");
+	/* ...and the rate was written where the snapshot reads it from. */
+	ASSERT_EQ(5, rss_config_get_int(st.cfg, "stream0", "jpeg_fps", 0));
+	/* The parent's own rate is not what was changed. */
+	ASSERT_EQ(0, rss_config_get_int(st.cfg, "stream0", "fps", 0));
+	teardown();
+	PASS();
+}
+
+/* The rate-control keys reach the encoder and are not written down:
+ * [stream0] bitrate/gop/min_qp/max_qp/rc_mode belong to the video
+ * stream, and a snapshot command must not redefine them. */
+TEST jpeg_rate_control_applies_without_persisting(void)
+{
+	setup();
+	rec.return_val = 0;
+
+	call("{\"cmd\":\"set-bitrate\",\"channel\":2,\"value\":4000000}");
+	ASSERT_EQ_FMT(4000000u, rec.set_bitrate, "%u");
+	ASSERT_EQ(4000000, (int)st.streams[2].enc_cfg.bitrate);
+	ASSERT_EQ(0, rss_config_get_int(st.cfg, "stream0", "bitrate", 0));
+
+	call("{\"cmd\":\"set-gop\",\"channel\":2,\"value\":10}");
+	ASSERT_EQ_FMT(10u, rec.set_gop, "%u");
+	ASSERT_EQ(0, rss_config_get_int(st.cfg, "stream0", "gop", 0));
+
+	call("{\"cmd\":\"set-qp-bounds\",\"channel\":2,\"min\":10,\"max\":40}");
+	ASSERT_EQ_FMT(10, rec.set_min_qp, "%d");
+	ASSERT_EQ_FMT(40, rec.set_max_qp, "%d");
+	ASSERT_EQ(0, rss_config_get_int(st.cfg, "stream0", "min_qp", 0));
+	ASSERT_EQ(0, rss_config_get_int(st.cfg, "stream0", "max_qp", 0));
+
+	call("{\"cmd\":\"set-rc-mode\",\"channel\":2,\"mode\":\"cbr\"}");
+	ASSERT_EQ(RSS_RC_CBR, rec.set_rc_mode);
+	ASSERT_STR_EQ("", rss_config_get_str(st.cfg, "stream0", "rc_mode", ""));
+
 	teardown();
 	PASS();
 }
@@ -1119,6 +1215,9 @@ SUITE(ctrl_suite)
 	RUN_TEST(set_fps_resets_a_fractional_den);
 	RUN_TEST(set_fps_publishes_the_channel_it_changed);
 	RUN_TEST(set_fps_no_publish_on_hal_failure);
+	RUN_TEST(jpeg_quality_persists_under_the_parent_section);
+	RUN_TEST(jpeg_fps_persists_under_the_jpeg_key);
+	RUN_TEST(jpeg_rate_control_applies_without_persisting);
 	RUN_TEST(sensor_fps_applies_min_rule_and_rescales_gop);
 	RUN_TEST(sensor_fps_decimated_substream_keeps_rate);
 	RUN_TEST(sensor_fps_zero_restores_base);


### PR DESCRIPTION
A snapshot channel never got a config section: rvd_pipeline builds it
from the parent video stream's settings and left cfg_sect empty. Any
runtime change to such a channel was then persisted into the empty
section, which lands as a sectionless line at the top of raptor.conf --
above every [section] header, where no loader ever reads it again:

    # Raptor Streaming System configuration
    # See raptor-docs/23-rss-config.md for full option reference
    bitrate = 2000000

Reachable from raptorctl alone, and worse than it looks for
set-jpeg-quality, which is the one command that only accepts a JPEG
channel: quality survived the daemon and was lost at the next boot.

The section is the parent's, because that is where a snapshot channel's
settings are read from. The keys are not: quality and frame rate live
there as jpeg_quality and jpeg_fps, so set-fps maps to jpeg_fps, and the
H.26x rate-control keys have no snapshot counterpart at all -- those
changes apply to the running encoder and are deliberately not written
down, since persisting them under the parent's plain key would retune
the video stream at the next boot from a command that never mentioned
it.

Board-verified on SSC377QE: set-bitrate, set-fps and set-jpeg-quality
against jpeg channel 2, then a config save -- jpeg_quality and jpeg_fps
land in [stream0], bitrate is applied and not written, and the top of
the file is untouched.

The ctrl suite's JPEG channel now carries the section rvd_pipeline hands
it, and pins the whole table: quality and rate land in the parent's
section as jpeg_quality and jpeg_fps, the parent's own fps is left
alone, and bitrate, gop, qp bounds and rc mode reach the encoder and are
written nowhere. Mutation-checked -- persisting every key under the
parent's plain name fails the rate and rate-control legs. The pipeline
half is the one no unit test can see, so an integration leg drives
set-jpeg-quality on the JPEG channel, saves, and reads the file back,
failing on any key written above the first [section] header. Suite goes
287 -> 290 unit tests and 139 -> 140 integration, still 0 fail.

