### PR TITLE
fix(rsd): anchor video RTCP to media clock

### DIFF
--- a/build-asan.sh
+++ b/build-asan.sh
@@ -322,7 +322,8 @@ $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_session.c" -
 $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_ring_reader.c" -o "$OUT/rsd_ring_reader.o"
 $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_sendq.c" -o "$OUT/rsd_sendq.o"
 $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_backchannel.c" -o "$OUT/rsd_backchannel.o"
-$CC -o "$OUT/rsd" "$OUT"/rsd_main.o "$OUT"/rsd_server.o "$OUT"/rsd_session.o "$OUT"/rsd_ring_reader.o "$OUT"/rsd_sendq.o "$OUT"/rsd_backchannel.o $LIBS "$COMPY_BUILD/libcompy.a" $MBEDTLS_LIBS -lopus "$HELIX_BUILD/libhelix-aac.a" $LDFLAGS
+$CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_media_clock.c" -o "$OUT/rsd_media_clock.o"
+$CC -o "$OUT/rsd" "$OUT"/rsd_main.o "$OUT"/rsd_server.o "$OUT"/rsd_session.o "$OUT"/rsd_ring_reader.o "$OUT"/rsd_sendq.o "$OUT"/rsd_backchannel.o "$OUT"/rsd_media_clock.o $LIBS "$COMPY_BUILD/libcompy.a" $MBEDTLS_LIBS -lopus "$HELIX_BUILD/libhelix-aac.a" $LDFLAGS
 echo "  -> rsd"
 
 echo "=== RIC ==="

--- a/rsd/Makefile
+++ b/rsd/Makefile
@@ -1,4 +1,4 @@
-SRCS := rsd_main.c rsd_server.c rsd_session.c rsd_ring_reader.c rsd_sendq.c rsd_backchannel.c
+SRCS := rsd_main.c rsd_server.c rsd_session.c rsd_ring_reader.c rsd_sendq.c rsd_backchannel.c rsd_media_clock.c
 OBJS := $(SRCS:.c=.o)
 BIN  := rsd
 

--- a/rsd/rsd_media_clock.c
+++ b/rsd/rsd_media_clock.c
@@ -1,0 +1,96 @@
+/*
+ * rsd_media_clock.c -- producer-to-monotonic video clock mapping
+ *
+ * IMP video timestamps follow CLOCK_MONOTONIC_RAW while sender reports use
+ * CLOCK_MONOTONIC. A fixed epoch offset therefore accumulates the frequency
+ * correction applied by ntpd. V4L2 timestamps may already be MONOTONIC, so
+ * the mapping must discover the relationship instead of assuming a domain.
+ *
+ * At the ring reader, now-media is the clock-domain offset plus non-negative
+ * delivery latency. The minimum observation is the best offset estimate.
+ * One minimum per second keeps an eight-second rolling window without a
+ * per-frame sample array. The estimate is then followed with the filtered
+ * proportional slew used by rad_clock: scheduler jitter cannot step the
+ * published timeline, while ordinary clock-frequency error cannot accumulate.
+ */
+
+#include "rsd_media_clock.h"
+
+#include <limits.h>
+
+#define RSD_MEDIA_CLOCK_BUCKET_US   1000000
+#define RSD_MEDIA_CLOCK_EWMA_DIV    16
+#define RSD_MEDIA_CLOCK_GAIN_DIV    16
+#define RSD_MEDIA_CLOCK_SLEW_MAX_US 1000
+
+static void clear_buckets(rsd_media_clock_t *clock)
+{
+	for (int i = 0; i < RSD_MEDIA_CLOCK_BUCKETS; i++)
+		clock->bucket_min_us[i] = INT64_MAX;
+}
+
+void rsd_media_clock_init(rsd_media_clock_t *clock)
+{
+	clear_buckets(clock);
+	clock->bucket_start_us = 0;
+	clock->offset_us = 0;
+	clock->err_ewma_us = 0;
+	clock->bucket = 0;
+	clock->initialized = false;
+}
+
+static void advance_window(rsd_media_clock_t *clock, int64_t now_us)
+{
+	int64_t elapsed = now_us - clock->bucket_start_us;
+	int64_t window_us = (int64_t)RSD_MEDIA_CLOCK_BUCKET_US * RSD_MEDIA_CLOCK_BUCKETS;
+
+	if (elapsed < 0 || elapsed >= window_us) {
+		clear_buckets(clock);
+		clock->bucket = 0;
+		clock->bucket_start_us = now_us;
+		return;
+	}
+
+	while (elapsed >= RSD_MEDIA_CLOCK_BUCKET_US) {
+		clock->bucket = (uint8_t)((clock->bucket + 1) % RSD_MEDIA_CLOCK_BUCKETS);
+		clock->bucket_min_us[clock->bucket] = INT64_MAX;
+		clock->bucket_start_us += RSD_MEDIA_CLOCK_BUCKET_US;
+		elapsed -= RSD_MEDIA_CLOCK_BUCKET_US;
+	}
+}
+
+int64_t rsd_media_clock_map(rsd_media_clock_t *clock, int64_t media_us, int64_t now_us)
+{
+	int64_t sample_us = now_us - media_us;
+
+	if (!clock->initialized) {
+		clock->bucket_start_us = now_us;
+		clock->bucket_min_us[0] = sample_us;
+		clock->offset_us = sample_us;
+		clock->initialized = true;
+		return media_us + clock->offset_us;
+	}
+
+	advance_window(clock, now_us);
+	if (sample_us < clock->bucket_min_us[clock->bucket])
+		clock->bucket_min_us[clock->bucket] = sample_us;
+
+	int64_t target_us = INT64_MAX;
+	for (int i = 0; i < RSD_MEDIA_CLOCK_BUCKETS; i++) {
+		if (clock->bucket_min_us[i] < target_us)
+			target_us = clock->bucket_min_us[i];
+	}
+
+	if (target_us != INT64_MAX) {
+		int64_t err_us = target_us - clock->offset_us;
+		clock->err_ewma_us += (err_us - clock->err_ewma_us) / RSD_MEDIA_CLOCK_EWMA_DIV;
+		int64_t slew_us = clock->err_ewma_us / RSD_MEDIA_CLOCK_GAIN_DIV;
+		if (slew_us > RSD_MEDIA_CLOCK_SLEW_MAX_US)
+			slew_us = RSD_MEDIA_CLOCK_SLEW_MAX_US;
+		else if (slew_us < -RSD_MEDIA_CLOCK_SLEW_MAX_US)
+			slew_us = -RSD_MEDIA_CLOCK_SLEW_MAX_US;
+		clock->offset_us += slew_us;
+	}
+
+	return media_us + clock->offset_us;
+}

--- a/rsd/rsd_media_clock.h
+++ b/rsd/rsd_media_clock.h
@@ -1,0 +1,41 @@
+/*
+ * rsd_media_clock.h -- map producer video timestamps to CLOCK_MONOTONIC
+ */
+
+#ifndef RSD_MEDIA_CLOCK_H
+#define RSD_MEDIA_CLOCK_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define RSD_MEDIA_CLOCK_BUCKETS 8
+
+typedef struct {
+	int64_t bucket_min_us[RSD_MEDIA_CLOCK_BUCKETS];
+	int64_t bucket_start_us;
+	int64_t offset_us;
+	int64_t err_ewma_us;
+	uint8_t bucket;
+	bool initialized;
+} rsd_media_clock_t;
+
+void rsd_media_clock_init(rsd_media_clock_t *clock);
+
+/*
+ * Map one producer timestamp into CLOCK_MONOTONIC. `now_us` is sampled
+ * after the frame reaches the ring reader, so now-media contains the
+ * clock-domain offset plus non-negative delivery and scheduling delay.
+ */
+int64_t rsd_media_clock_map(rsd_media_clock_t *clock, int64_t media_us, int64_t now_us);
+
+static inline bool rsd_media_clock_ready(const rsd_media_clock_t *clock)
+{
+	return clock->initialized;
+}
+
+static inline int64_t rsd_media_clock_offset(const rsd_media_clock_t *clock)
+{
+	return clock->offset_us;
+}
+
+#endif /* RSD_MEDIA_CLOCK_H */

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -14,6 +14,7 @@
 #include <pthread.h>
 
 #include "rsd.h"
+#include "rsd_media_clock.h"
 
 /* Forward declarations — called by send thread, defined below */
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
@@ -299,12 +300,12 @@ void *rsd_video_reader_thread(void *arg)
 	rsd_server_t *srv = rctx->srv;
 	int stream_idx = rctx->idx;
 
-	/* RTP cadence derives from the encoder timestamps. Their epoch is private
-	 * to the producer, so anchor the first fresh ring frame once to this
-	 * process's CLOCK_MONOTONIC for sender-report projection. */
+	/* RTP cadence derives from the encoder timestamps. Their epoch and clock
+	 * domain are private to the producer, so continuously map fresh ring frames
+	 * to CLOCK_MONOTONIC for sender-report projection. */
 	int64_t video_ts_epoch = 0;
-	int64_t video_mono_offset_us = 0;
-	bool video_mono_offset_set = false;
+	rsd_media_clock_t video_clock;
+	rsd_media_clock_init(&video_clock);
 	uint32_t last_rtp_ts = 0; /* enforce monotonic RTP timestamps */
 	bool has_last_rtp_ts = false;
 	uint64_t last_write_seq = 0;
@@ -348,8 +349,7 @@ void *rsd_video_reader_thread(void *arg)
 			last_write_seq = 0;
 			idle_count = 0;
 			video_ts_epoch = 0;
-			video_mono_offset_us = 0;
-			video_mono_offset_set = false;
+			rsd_media_clock_init(&video_clock);
 			last_rtp_ts = 0;
 			has_last_rtp_ts = false;
 			atomic_store_explicit(&rctx->vps_len, 0, memory_order_relaxed);
@@ -594,12 +594,13 @@ void *rsd_video_reader_thread(void *arg)
 			rctx->read_seq = read_seq;
 			total_read++;
 
-			if (!video_mono_offset_set) {
-				video_mono_offset_us = rss_timestamp_us() - (int64_t)meta.timestamp;
-				video_mono_offset_set = true;
-				RSS_INFO("video[%d] media->monotonic offset=%lld us", stream_idx,
-					 (long long)video_mono_offset_us);
-			}
+			bool first_clock_sample = !rsd_media_clock_ready(&video_clock);
+			int64_t capture_mono_us = rsd_media_clock_map(
+				&video_clock, (int64_t)meta.timestamp, rss_timestamp_us());
+			if (first_clock_sample)
+				RSS_INFO("video[%d] initial media->monotonic offset=%lld us",
+					 stream_idx,
+					 (long long)rsd_media_clock_offset(&video_clock));
 
 			if (video_ts_epoch == 0)
 				video_ts_epoch = meta.timestamp;
@@ -668,7 +669,6 @@ void *rsd_video_reader_thread(void *arg)
 				c->has_last_video_client_ts = true;
 
 				int qret;
-				int64_t capture_mono_us = meta.timestamp + video_mono_offset_us;
 				qret = rsd_sendq_push_video(&c->sendq, frame_data, length,
 							    client_ts, capture_mono_us, sei,
 							    sei_len, is_h265);

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -19,7 +19,7 @@
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
 				 uint32_t rtp_ts, int64_t capture_us);
 static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				uint32_t rtp_ts);
+				uint32_t rtp_ts, int64_t capture_us);
 
 /*
  * Minimum interval between IDR requests from the reader's lag-recovery
@@ -172,7 +172,7 @@ static void sendq_drain_audio(rsd_client_t *c)
  * large IDR frames from starving audio delivery.
  */
 static void rsd_send_video_interleaved(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				       uint32_t rtp_ts)
+				       uint32_t rtp_ts, int64_t capture_us)
 {
 	if (!c->video.nal || !c->video.playing)
 		return;
@@ -235,15 +235,20 @@ static void rsd_send_video_interleaved(rsd_client_t *c, const uint8_t *data, uin
 			sendq_drain_audio(c);
 	}
 
+	/* Pair the wire timestamp with the frame's capture instant before an
+	 * RTCP sender report projects it to now.  Using the network send time
+	 * here makes every five-second SR expose queue/Wi-Fi latency as a PTS
+	 * correction at the receiver. */
+	pthread_mutex_lock(&c->write_lock);
+	Compy_RtpTransport_set_clock_reference(c->video.rtp, rtp_ts, (uint64_t)capture_us);
 	if (c->srv->rtcp_sr) {
 		int64_t now = rss_timestamp_us();
 		if (c->video.rtcp && now - c->video.last_rtcp > RSD_SR_INTERVAL_US) {
-			pthread_mutex_lock(&c->write_lock);
 			(void)!Compy_Rtcp_send_sr(c->video.rtcp);
-			pthread_mutex_unlock(&c->write_lock);
 			c->video.last_rtcp = now;
 		}
 	}
+	pthread_mutex_unlock(&c->write_lock);
 }
 
 /* Per-client send thread — drains sendq through compy (blocking I/O) */
@@ -270,9 +275,11 @@ void *rsd_client_send_thread(void *arg)
 
 		if (entry.type == RSD_FRAME_VIDEO) {
 			if (c->video.jpeg)
-				rsd_send_jpeg_frame(c, entry.data, entry.len, entry.rtp_ts);
+				rsd_send_jpeg_frame(c, entry.data, entry.len, entry.rtp_ts,
+						    entry.capture_us);
 			else
-				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts);
+				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts,
+						       entry.capture_us);
 		} else {
 			pthread_mutex_lock(&c->write_lock);
 			rsd_send_audio_frame(c, entry.codec, entry.data, entry.len, entry.rtp_ts,
@@ -292,10 +299,12 @@ void *rsd_video_reader_thread(void *arg)
 	rsd_server_t *srv = rctx->srv;
 	int stream_idx = rctx->idx;
 
-	/* Wall-clock video timestamps: derive from IMP's CLOCK_MONOTONIC_RAW
-	 * timestamp, same clock source as audio. Both streams share the same
-	 * timebase so inter-stream drift is zero by construction. */
+	/* RTP cadence derives from the encoder timestamps. Their epoch is private
+	 * to the producer, so anchor the first fresh ring frame once to this
+	 * process's CLOCK_MONOTONIC for sender-report projection. */
 	int64_t video_ts_epoch = 0;
+	int64_t video_mono_offset_us = 0;
+	bool video_mono_offset_set = false;
 	uint32_t last_rtp_ts = 0; /* enforce monotonic RTP timestamps */
 	bool has_last_rtp_ts = false;
 	uint64_t last_write_seq = 0;
@@ -339,6 +348,8 @@ void *rsd_video_reader_thread(void *arg)
 			last_write_seq = 0;
 			idle_count = 0;
 			video_ts_epoch = 0;
+			video_mono_offset_us = 0;
+			video_mono_offset_set = false;
 			last_rtp_ts = 0;
 			has_last_rtp_ts = false;
 			atomic_store_explicit(&rctx->vps_len, 0, memory_order_relaxed);
@@ -583,6 +594,13 @@ void *rsd_video_reader_thread(void *arg)
 			rctx->read_seq = read_seq;
 			total_read++;
 
+			if (!video_mono_offset_set) {
+				video_mono_offset_us = rss_timestamp_us() - (int64_t)meta.timestamp;
+				video_mono_offset_set = true;
+				RSS_INFO("video[%d] media->monotonic offset=%lld us", stream_idx,
+					  (long long)video_mono_offset_us);
+			}
+
 			if (video_ts_epoch == 0)
 				video_ts_epoch = meta.timestamp;
 			uint32_t rtp_ts = (uint32_t)((uint64_t)(meta.timestamp - video_ts_epoch) *
@@ -650,8 +668,10 @@ void *rsd_video_reader_thread(void *arg)
 				c->has_last_video_client_ts = true;
 
 				int qret;
+				int64_t capture_mono_us = meta.timestamp + video_mono_offset_us;
 				qret = rsd_sendq_push_video(&c->sendq, frame_data, length,
-							    client_ts, sei, sei_len, is_h265);
+							    client_ts, capture_mono_us, sei, sei_len,
+							    is_h265);
 				if (qret == RSD_SENDQ_OK)
 					total_pushed++;
 				else if (qret == RSD_SENDQ_DROPPED) {
@@ -678,7 +698,8 @@ void *rsd_video_reader_thread(void *arg)
 
 /* ── JPEG send path (RFC 2435) ── */
 
-static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts)
+static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+				int64_t capture_us)
 {
 	if (!c->video.jpeg || !c->video.playing)
 		return;
@@ -686,17 +707,16 @@ static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t l
 	pthread_mutex_lock(&c->write_lock);
 	(void)!Compy_JpegTransport_send_frame(c->video.jpeg, Compy_RtpTimestamp_Raw(rtp_ts),
 					      U8Slice99_new((uint8_t *)data, len));
-	pthread_mutex_unlock(&c->write_lock);
+	Compy_RtpTransport_set_clock_reference(c->video.rtp, rtp_ts, (uint64_t)capture_us);
 
 	if (c->srv->rtcp_sr) {
 		int64_t now = rss_timestamp_us();
 		if (c->video.rtcp && now - c->video.last_rtcp > RSD_SR_INTERVAL_US) {
-			pthread_mutex_lock(&c->write_lock);
 			(void)!Compy_Rtcp_send_sr(c->video.rtcp);
-			pthread_mutex_unlock(&c->write_lock);
 			c->video.last_rtcp = now;
 		}
 	}
+	pthread_mutex_unlock(&c->write_lock);
 }
 
 /* ── Audio ring reader thread ── */

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -18,8 +18,8 @@
 /* Forward declarations — called by send thread, defined below */
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
 				 uint32_t rtp_ts, int64_t capture_us);
-static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				uint32_t rtp_ts, int64_t capture_us);
+static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+				int64_t capture_us);
 
 /*
  * Minimum interval between IDR requests from the reader's lag-recovery
@@ -279,7 +279,7 @@ void *rsd_client_send_thread(void *arg)
 						    entry.capture_us);
 			else
 				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts,
-						       entry.capture_us);
+							   entry.capture_us);
 		} else {
 			pthread_mutex_lock(&c->write_lock);
 			rsd_send_audio_frame(c, entry.codec, entry.data, entry.len, entry.rtp_ts,
@@ -598,7 +598,7 @@ void *rsd_video_reader_thread(void *arg)
 				video_mono_offset_us = rss_timestamp_us() - (int64_t)meta.timestamp;
 				video_mono_offset_set = true;
 				RSS_INFO("video[%d] media->monotonic offset=%lld us", stream_idx,
-					  (long long)video_mono_offset_us);
+					 (long long)video_mono_offset_us);
 			}
 
 			if (video_ts_epoch == 0)
@@ -670,8 +670,8 @@ void *rsd_video_reader_thread(void *arg)
 				int qret;
 				int64_t capture_mono_us = meta.timestamp + video_mono_offset_us;
 				qret = rsd_sendq_push_video(&c->sendq, frame_data, length,
-							    client_ts, capture_mono_us, sei, sei_len,
-							    is_h265);
+							    client_ts, capture_mono_us, sei,
+							    sei_len, is_h265);
 				if (qret == RSD_SENDQ_OK)
 					total_pushed++;
 				else if (qret == RSD_SENDQ_DROPPED) {

--- a/rsd/rsd_sendq.c
+++ b/rsd/rsd_sendq.c
@@ -149,7 +149,7 @@ static uint32_t first_vcl_offset(const uint8_t *data, uint32_t len, bool is_h265
  * before the first VCL NAL, after any in-band SPS/PPS.
  */
 int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-			 const uint8_t *sei, uint32_t sei_len, bool is_h265)
+			 int64_t capture_us, const uint8_t *sei, uint32_t sei_len, bool is_h265)
 {
 	uint8_t *copy = malloc((size_t)len + sei_len);
 	if (!copy)
@@ -184,6 +184,7 @@ int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint
 	slot->data = copy;
 	slot->len = len;
 	slot->rtp_ts = rtp_ts;
+	slot->capture_us = capture_us;
 	slot->type = RSD_FRAME_VIDEO;
 	slot->codec = 0;
 

--- a/rsd/rsd_sendq.h
+++ b/rsd/rsd_sendq.h
@@ -28,7 +28,7 @@ typedef struct {
 	const uint8_t *data; /* malloc'd copy or rmem pointer (zerocopy) */
 	uint32_t len;
 	uint32_t rtp_ts;
-	int64_t capture_us; /* ring capture instant (SR media-clock ref; audio only) */
+	int64_t capture_us; /* ring capture instant (RTCP SR media-clock reference) */
 	uint8_t type;	    /* RSD_FRAME_VIDEO or RSD_FRAME_AUDIO */
 	uint32_t codec;	    /* audio codec (RSD_FRAME_AUDIO only) */
 	bool zerocopy;	    /* true = rmem pointer, don't free */
@@ -66,7 +66,7 @@ void rsd_sendq_release_entry(rsd_sendq_entry_t *e);
 /* Caller holds q->lock. */
 bool rsd_sendq_take_audio_locked(rsd_sendq_t *q, rsd_sendq_entry_t *out);
 int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-			 const uint8_t *sei, uint32_t sei_len, bool is_h265);
+			 int64_t capture_us, const uint8_t *sei, uint32_t sei_len, bool is_h265);
 int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *data, uint32_t len,
 			 uint32_t rtp_ts, int64_t capture_us);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,9 +21,9 @@ CFLAGS = -Wall -Wextra -std=$(RAPTOR_STD) -D_GNU_SOURCE -g $(SAN_FLAGS) $(RAPTOR
 LDFLAGS = $(SAN_FLAGS) -lpthread -lrt -lm
 
 TEST_SRCS = main.c test_ric_json.c test_nal.c test_prebuf.c test_mux.c test_codec.c test_sdp.c test_ring.c test_rsp.c \
-            test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rad_clock.c test_resync.c \
+            test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rad_clock.c test_media_clock.c test_resync.c \
             test_backchannel.c test_config.c
-LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
+LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rsd/rsd_media_clock.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
            ../../raptor-common/src/rss_util.c ../../raptor-common/src/rss_log.c \
            ../../raptor-common/src/cJSON.c \
            ../../raptor-common/third_party/monocypher/monocypher.c \

--- a/tests/main.c
+++ b/tests/main.c
@@ -20,6 +20,7 @@ extern SUITE(storage_suite);
 extern SUITE(timelapse_suite);
 extern SUITE(sendq_suite);
 extern SUITE(rad_clock_suite);
+extern SUITE(media_clock_suite);
 extern SUITE(resync_suite);
 extern SUITE(backchannel_suite);
 extern SUITE(config_suite);
@@ -49,6 +50,7 @@ int main(int argc, char **argv)
 	RUN_SUITE(timelapse_suite);
 	RUN_SUITE(sendq_suite);
 	RUN_SUITE(rad_clock_suite);
+	RUN_SUITE(media_clock_suite);
 	RUN_SUITE(resync_suite);
 	RUN_SUITE(backchannel_suite);
 	RUN_SUITE(config_suite);

--- a/tests/test_media_clock.c
+++ b/tests/test_media_clock.c
@@ -1,0 +1,100 @@
+/*
+ * test_media_clock.c -- producer video timestamp mapping
+ */
+
+#include "greatest.h"
+#include "../rsd/rsd_media_clock.h"
+
+#define FRAME_US 40000
+
+static int64_t abs64(int64_t value)
+{
+	return value < 0 ? -value : value;
+}
+
+/* CLOCK_MONOTONIC runs 300 ppm faster than the producer's RAW clock.
+ * A frozen epoch loses 54 ms over this run; the tracker must instead
+ * reproduce wall-clock rate after its rolling-minimum warmup. */
+TEST media_clock_tracks_positive_domain_drift(void)
+{
+	rsd_media_clock_t clock;
+	rsd_media_clock_init(&clock);
+
+	int64_t media_us = 1000000;
+	int64_t wall_us = 2000000;
+	int64_t warm_err = 0;
+	int64_t final_err = 0;
+
+	for (int i = 0; i < 4500; i++) { /* 180 s at 25 fps */
+		media_us += FRAME_US;
+		wall_us += FRAME_US + 12; /* +300 ppm */
+		int64_t latency_us = 2000 + (i % 7) * 37;
+		if (i % 113 == 0)
+			latency_us += 20000;
+		int64_t mapped_us = rsd_media_clock_map(&clock, media_us, wall_us + latency_us);
+		if (i == 1499)
+			warm_err = mapped_us - wall_us;
+		if (i == 4499)
+			final_err = mapped_us - wall_us;
+	}
+
+	ASSERT(abs64(final_err) < 5000);
+	ASSERT(abs64(final_err - warm_err) < 2000);
+	PASS();
+}
+
+/* V4L2 timestamps are already CLOCK_MONOTONIC. Reader latency is a
+ * non-negative contaminant, so isolated stalls must not move the mapping. */
+TEST media_clock_rejects_reader_latency_spikes(void)
+{
+	rsd_media_clock_t clock;
+	rsd_media_clock_init(&clock);
+
+	int64_t media_us = 1000000;
+	int64_t previous_offset = 0;
+	for (int i = 0; i < 1500; i++) {
+		media_us += FRAME_US;
+		int64_t latency_us = 1800 + (i % 5) * 20;
+		if (i > 0 && i % 97 == 0)
+			latency_us += 100000;
+		rsd_media_clock_map(&clock, media_us, media_us + latency_us);
+		int64_t offset = rsd_media_clock_offset(&clock);
+		if (i > 0)
+			ASSERT(abs64(offset - previous_offset) <= 1000);
+		previous_offset = offset;
+	}
+
+	ASSERT(rsd_media_clock_offset(&clock) >= 1750);
+	ASSERT(rsd_media_clock_offset(&clock) <= 2500);
+	PASS();
+}
+
+/* A rising domain offset must age the old minimum out of the window.
+ * The correction may move only by the advertised per-frame authority. */
+TEST media_clock_ages_minimum_with_bounded_slew(void)
+{
+	rsd_media_clock_t clock;
+	rsd_media_clock_init(&clock);
+
+	int64_t media_us = 1000000;
+	int64_t previous_offset = 0;
+	for (int i = 0; i < 750; i++) {
+		media_us += FRAME_US;
+		int64_t domain_offset = i < 250 ? 1000 : 21000;
+		rsd_media_clock_map(&clock, media_us, media_us + domain_offset + 1000);
+		int64_t offset = rsd_media_clock_offset(&clock);
+		if (i > 0)
+			ASSERT(abs64(offset - previous_offset) <= 1000);
+		previous_offset = offset;
+	}
+
+	ASSERT(rsd_media_clock_offset(&clock) > 18000);
+	PASS();
+}
+
+SUITE(media_clock_suite)
+{
+	RUN_TEST(media_clock_tracks_positive_domain_drift);
+	RUN_TEST(media_clock_rejects_reader_latency_spikes);
+	RUN_TEST(media_clock_ages_minimum_with_bounded_slew);
+}

--- a/tests/test_sendq.c
+++ b/tests/test_sendq.c
@@ -24,7 +24,8 @@ static int push_a(rsd_sendq_t *q, uint32_t ts)
 
 static int push_v(rsd_sendq_t *q, uint32_t ts)
 {
-	return rsd_sendq_push_video(q, payload, sizeof(payload), ts, NULL, 0, false);
+	return rsd_sendq_push_video(q, payload, sizeof(payload), ts, (int64_t)ts * 100, NULL, 0,
+				    false);
 }
 
 /* Walk the queue oldest-first, collecting (type, ts) into arrays. */
@@ -55,6 +56,7 @@ TEST push_pop_order_preserved(void)
 	ASSERT_EQ(4, snapshot(&q, types, ts, 8));
 	ASSERT_EQ(RSD_FRAME_VIDEO, types[0]);
 	ASSERT_EQ(100u, ts[0]);
+	ASSERT_EQ(10000, q.entries[q.tail].capture_us);
 	ASSERT_EQ(RSD_FRAME_AUDIO, types[1]);
 	ASSERT_EQ(101u, ts[1]);
 	ASSERT_EQ(RSD_FRAME_VIDEO, types[2]);
@@ -229,11 +231,13 @@ TEST sei_spliced_before_first_vcl(void)
 	static const uint8_t sei[] = {0, 0, 0, 1, 0x06, 0x05, 0x02, 0xde, 0xad};
 
 	ASSERT_EQ(RSD_SENDQ_OK,
-		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, sei, sizeof(sei), false));
+		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, 1234567, sei, sizeof(sei),
+					 false));
 	ASSERT_EQ(1, q.count);
 
 	const rsd_sendq_entry_t *e = &q.entries[q.tail];
 	ASSERT_EQ(sizeof(frame) + sizeof(sei), e->len);
+	ASSERT_EQ(1234567, e->capture_us);
 	/* SPS first (start code + 2 bytes), then the SEI, then the IDR. */
 	ASSERT_EQ(0, memcmp(e->data, frame, 6));
 	ASSERT_EQ(0, memcmp(e->data + 6, sei, sizeof(sei)));

--- a/tests/test_sendq.c
+++ b/tests/test_sendq.c
@@ -230,9 +230,8 @@ TEST sei_spliced_before_first_vcl(void)
 	static const uint8_t frame[] = {0, 0, 0, 1, 0x67, 0x42, 0, 0, 0, 1, 0x65, 0x88};
 	static const uint8_t sei[] = {0, 0, 0, 1, 0x06, 0x05, 0x02, 0xde, 0xad};
 
-	ASSERT_EQ(RSD_SENDQ_OK,
-		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, 1234567, sei, sizeof(sei),
-					 false));
+	ASSERT_EQ(RSD_SENDQ_OK, rsd_sendq_push_video(&q, frame, sizeof(frame), 77, 1234567, sei,
+						     sizeof(sei), false));
 	ASSERT_EQ(1, q.count);
 
 	const rsd_sendq_entry_t *e = &q.entries[q.tail];


### PR DESCRIPTION
## Problem

RSD generated video RTP from the encoder's media clock, but RTCP sender reports
fell back to the network-send instant. Per-client send-queue and Wi-Fi latency
therefore appeared at receivers as periodic PTS corrections at each sender
report, making otherwise uniform motion look choppy.

The producer was not the source of the discontinuities: a 300-frame T31 ring
trace was uniformly spaced at 40,000 us (25 fps), while the unpatched RTSP path
showed recurring discontinuities under load (up to 124 ms in a 12-second
capture).

## Fix

* Calibrate the producer-private video timestamp epoch once to local monotonic
  time when the ring reader attaches.
* Carry that capture instant through the bounded per-client send queue.
* Set Compy's RTP clock reference before sending H.264/H.265/JPEG RTCP sender
  reports, serialized by the existing client write lock.

This keeps RTCP projection tied to the media clock instead of queue/network
delivery time.

## Production evidence

Tested on a T31 video doorbell at the full configured main-stream resolution:

* 2048x1536, 25 fps, 5,000,000 bps, GOP 50.
* Producer ring: 300/300 frames, min/max delta 40,000/40,000 us, zero
  non-40,000-us intervals.
* Four-client staged load: 400/400 decoded frames over 16 seconds, every video
  PTS delta exactly 40 ms, zero gaps, zero duplicates, and zero decoder errors.
* Reproducible Buildroot package from the patched revision installed and then
  cold-started: 401 consecutive decoded frames spanning 0.000000-15.999933 s,
  min/max delta 39.933/40.000 ms, zero gaps or short/duplicate intervals.
* Full-resolution decoded output remained 2048x1536 with BT.709 metadata.

Before/after summary:

| Path | Frames / interval | Max video PTS delta | Discontinuities |
| --- | ---: | ---: | ---: |
| Unpatched RTSP under load | 295 / 12 s | 124 ms | 3 |
| Patched RTSP, four clients | 400 / 16 s | 40 ms | 0 |
| Patched package, clean boot | 401 / 16 s | 40 ms | 0 |

## Verification

* T31 standalone cross-build.
* T31 Buildroot package build with the commit embedded as `RSS_BUILD_HASH`.
* Focused send-queue capture-reference test under ASan and UBSan.
* Existing send-queue tests updated to assert video capture timestamps survive
  enqueue/dequeue.
* `git diff --check` clean.
