### PR TITLE
fix(rvd): initialize V4L2 from the active sensor

### DIFF
--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -2450,14 +2450,14 @@ int rvd_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 	if (rss_json_get_str(cmd_json, "cmd", cmd, sizeof(cmd)) != 0)
 		return rss_ctrl_resp_error(resp_buf, resp_buf_size, "missing cmd");
 
-	/* The standalone backend has no initialized IMP HAL graph. Keep its small
-	 * control surface explicit so a web/API request cannot fall through to an
-	 * operation on uninitialized SDK state. */
+	/* The standalone backend initializes the ISP HAL for sensor bring-up and
+	 * tuning, but it has no IMP framesource or encoder graph. Keep its control
+	 * surface explicit so only controls backed by initialized state get through. */
 	if (st->v4l2_backend && strcmp(cmd, "request-idr") != 0 &&
 	    strcmp(cmd, "get-bitrate") != 0 && strcmp(cmd, "get-fps") != 0 &&
 	    strcmp(cmd, "get-gop") != 0 && strcmp(cmd, "get-qp-bounds") != 0 &&
-	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "config-show") != 0 &&
-	    strcmp(cmd, "status") != 0)
+	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "get-sensor-fps") != 0 &&
+	    strcmp(cmd, "config-show") != 0 && strcmp(cmd, "status") != 0)
 		return rss_ctrl_resp_error(resp_buf, resp_buf_size,
 					   "not supported by the V4L2 backend");
 

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -208,6 +208,7 @@ static const char *rc_mode_str(rss_rc_mode_t m)
 static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
 			       int default_w, int default_h, int default_fps, int default_br);
 static int read_sensor_proc_int(int idx, const char *key, int base, int def);
+static int find_active_sensor_proc_index(void);
 static void load_sensor_from_section(rss_config_t *cfg, const char *section,
 				     rss_sensor_config_t *sensor, int proc_idx);
 
@@ -219,6 +220,8 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	int sensor_w;
 	int sensor_h;
 	int sensor_fps;
+	int sensor_proc_idx;
+	bool sensor_fps_known;
 	int ret;
 
 	device = rss_config_get_str(st->cfg, "system", "video_device", "/dev/video0");
@@ -261,19 +264,21 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	}
 	st->hal_initialized = true;
 
-	sensor_w = read_sensor_proc_int(0, "width", 10, 0);
-	sensor_h = read_sensor_proc_int(0, "height", 10, 0);
+	sensor_proc_idx = find_active_sensor_proc_index();
+	sensor_w = read_sensor_proc_int(sensor_proc_idx, "width", 10, 0);
+	sensor_h = read_sensor_proc_int(sensor_proc_idx, "height", 10, 0);
 	if (sensor_w > 0 && sensor_h > 0) {
-		RSS_INFO("sensor resolution: %dx%d", sensor_w, sensor_h);
+		RSS_INFO("active sensor%d: %dx%d", sensor_proc_idx, sensor_w, sensor_h);
 	} else {
 		sensor_w = 1920;
 		sensor_h = 1080;
-		RSS_WARN("could not determine sensor resolution; using %dx%d",
+		RSS_WARN("could not determine active sensor resolution; using %dx%d",
 			 sensor_w, sensor_h);
 	}
-	sensor_fps = read_sensor_proc_int(0, "max_fps", 10, 0);
+	sensor_fps = read_sensor_proc_int(sensor_proc_idx, "max_fps", 10, 0);
 	if (sensor_fps <= 0)
-		sensor_fps = read_sensor_proc_int(0, "fps", 10, 0);
+		sensor_fps = read_sensor_proc_int(sensor_proc_idx, "fps", 10, 0);
+	sensor_fps_known = sensor_fps > 0;
 	if (sensor_fps <= 0)
 		sensor_fps = 25;
 
@@ -286,6 +291,33 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	if (stream->enc_cfg.codec != RSS_CODEC_H264) {
 		RSS_FATAL("V4L2 backend currently requires stream0 codec=h264");
 		return RSS_ERR_NOTSUP;
+	}
+
+	/*
+	 * The public V4L2 node emits every frame produced by the active sensor;
+	 * it has no IMP framesource decimator.  Keep encoder rate control, GOP
+	 * defaults, ring metadata and downstream RTP on that measured clock.
+	 * Reprogramming the physical sensor here is unsafe: some sensor drivers
+	 * advertise the generic FPS control but cannot switch modes while the
+	 * ISP pipeline is active.
+	 */
+	if (sensor_fps_known &&
+	    (stream->enc_cfg.fps_num != (uint32_t)sensor_fps ||
+	     stream->enc_cfg.fps_den != 1)) {
+		RSS_WARN("V4L2 stream0 rate %u/%u overridden by active sensor%d rate %d/1",
+			 stream->enc_cfg.fps_num, stream->enc_cfg.fps_den, sensor_proc_idx,
+			 sensor_fps);
+		stream->fs_cfg.fps_num = (uint32_t)sensor_fps;
+		stream->fs_cfg.fps_den = 1;
+		stream->enc_cfg.fps_num = (uint32_t)sensor_fps;
+		stream->enc_cfg.fps_den = 1;
+		if (!rss_config_get_str(st->cfg, "stream0", "gop", NULL))
+			stream->enc_cfg.gop_length = (uint32_t)sensor_fps;
+	}
+	if (sensor_fps_known) {
+		st->sensor_base_fps_num = (uint32_t)sensor_fps;
+		st->sensor_base_fps_den = 1;
+		RSS_INFO("sensor%d fps: %d/1", sensor_proc_idx, sensor_fps);
 	}
 	if (rss_config_get_bool(st->cfg, "stream1", "enabled", true) ||
 	    rss_config_get_bool(st->cfg, "jpeg", "enabled", true) ||
@@ -361,6 +393,31 @@ static int read_sensor_proc_int(int idx, const char *key, int base, int def)
 	char path[64];
 	sensor_proc_path(path, sizeof(path), idx, key);
 	return read_procfs_int(path, base, def);
+}
+
+static int find_active_sensor_proc_index(void)
+{
+	for (int idx = 0; idx < RVD_MAX_SENSORS; idx++) {
+		char path[64];
+		char *status;
+		char *end;
+
+		sensor_proc_path(path, sizeof(path), idx, "status");
+		status = rss_read_file(path, NULL);
+		if (!status)
+			continue;
+		end = status + strlen(status);
+		while (end > status && (end[-1] == '\n' || end[-1] == '\r' || end[-1] == ' ' ||
+					end[-1] == '\t'))
+			*--end = '\0';
+		if (strcmp(status, "active") == 0) {
+			free(status);
+			return idx;
+		}
+		free(status);
+	}
+
+	return 0;
 }
 
 /* Load sensor config from an INI section, with a per-index procfs

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -272,8 +272,8 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	} else {
 		sensor_w = 1920;
 		sensor_h = 1080;
-		RSS_WARN("could not determine active sensor resolution; using %dx%d",
-			 sensor_w, sensor_h);
+		RSS_WARN("could not determine active sensor resolution; using %dx%d", sensor_w,
+			 sensor_h);
 	}
 	sensor_fps = read_sensor_proc_int(sensor_proc_idx, "max_fps", 10, 0);
 	if (sensor_fps <= 0)
@@ -282,8 +282,7 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	if (sensor_fps <= 0)
 		sensor_fps = 25;
 
-	load_stream_config(st->cfg, "stream0", stream, sensor_w, sensor_h, sensor_fps,
-			   8000000);
+	load_stream_config(st->cfg, "stream0", stream, sensor_w, sensor_h, sensor_fps, 8000000);
 	stream->fs_chn = 0;
 	stream->chn = 0;
 	stream->sensor_idx = 0;
@@ -302,8 +301,7 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	 * ISP pipeline is active.
 	 */
 	if (sensor_fps_known &&
-	    (stream->enc_cfg.fps_num != (uint32_t)sensor_fps ||
-	     stream->enc_cfg.fps_den != 1)) {
+	    (stream->enc_cfg.fps_num != (uint32_t)sensor_fps || stream->enc_cfg.fps_den != 1)) {
 		RSS_WARN("V4L2 stream0 rate %u/%u overridden by active sensor%d rate %d/1",
 			 stream->enc_cfg.fps_num, stream->enc_cfg.fps_den, sensor_proc_idx,
 			 sensor_fps);
@@ -407,8 +405,8 @@ static int find_active_sensor_proc_index(void)
 		if (!status)
 			continue;
 		end = status + strlen(status);
-		while (end > status && (end[-1] == '\n' || end[-1] == '\r' || end[-1] == ' ' ||
-					end[-1] == '\t'))
+		while (end > status &&
+		       (end[-1] == '\n' || end[-1] == '\r' || end[-1] == ' ' || end[-1] == '\t'))
 			*--end = '\0';
 		if (strcmp(status, "active") == 0) {
 			free(status);

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -208,9 +208,12 @@ static const char *rc_mode_str(rss_rc_mode_t m)
 static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
 			       int default_w, int default_h, int default_fps, int default_br);
 static int read_sensor_proc_int(int idx, const char *key, int base, int def);
+static void load_sensor_from_section(rss_config_t *cfg, const char *section,
+				     rss_sensor_config_t *sensor, int proc_idx);
 
 static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 {
+	rss_multi_sensor_config_t multi_cfg = {0};
 	rvd_stream_t *stream = &st->streams[0];
 	const char *device;
 	int sensor_w;
@@ -230,6 +233,33 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	st->use_isp_osd = false;
 	st->ivs_enabled = false;
 	atomic_store(&st->ivs_active, false);
+
+	/* V4L2 exposes frames from the TX-ISP pipeline, but opening /dev/video0
+	 * does not bind or start the sensor. Bring up ISP + sensor through the
+	 * same HAL sequence as the regular IMP pipeline before configuring the
+	 * capture and encoder backends. */
+	load_sensor_from_section(st->cfg, "sensor", &multi_cfg.sensors[0], 0);
+	multi_cfg.sensor_count = 1;
+	if (!multi_cfg.sensors[0].name[0]) {
+		RSS_FATAL("sensor name not in config and not in /proc/jz/sensor/sensor0/name");
+		return RSS_ERR;
+	}
+	if (multi_cfg.sensors[0].i2c_addr == 0) {
+		RSS_FATAL("i2c_addr not in config and not in /proc/jz/sensor/sensor0/i2c_addr");
+		return RSS_ERR;
+	}
+	RSS_DEBUG("sensor0: %s i2c=0x%02x bus=%d id=%d mclk=%d vin=%d boot=%d",
+		  multi_cfg.sensors[0].name, multi_cfg.sensors[0].i2c_addr,
+		  multi_cfg.sensors[0].i2c_adapter, multi_cfg.sensors[0].sensor_id,
+		  multi_cfg.sensors[0].mclk, multi_cfg.sensors[0].vin_type,
+		  multi_cfg.sensors[0].default_boot);
+
+	ret = RSS_HAL_CALL(st->ops, init, st->hal_ctx, &multi_cfg);
+	if (ret != RSS_OK) {
+		RSS_FATAL("HAL init failed: %d", ret);
+		return ret;
+	}
+	st->hal_initialized = true;
 
 	sensor_w = read_sensor_proc_int(0, "width", 10, 0);
 	sensor_h = read_sensor_proc_int(0, "height", 10, 0);

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -207,11 +207,15 @@ static const char *rc_mode_str(rss_rc_mode_t m)
 
 static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
 			       int default_w, int default_h, int default_fps, int default_br);
+static int read_sensor_proc_int(int idx, const char *key, int base, int def);
 
 static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 {
 	rvd_stream_t *stream = &st->streams[0];
 	const char *device;
+	int sensor_w;
+	int sensor_h;
+	int sensor_fps;
 	int ret;
 
 	device = rss_config_get_str(st->cfg, "system", "video_device", "/dev/video0");
@@ -227,7 +231,24 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	st->ivs_enabled = false;
 	atomic_store(&st->ivs_active, false);
 
-	load_stream_config(st->cfg, "stream0", stream, 2560, 1440, 25, 8000000);
+	sensor_w = read_sensor_proc_int(0, "width", 10, 0);
+	sensor_h = read_sensor_proc_int(0, "height", 10, 0);
+	if (sensor_w > 0 && sensor_h > 0) {
+		RSS_INFO("sensor resolution: %dx%d", sensor_w, sensor_h);
+	} else {
+		sensor_w = 1920;
+		sensor_h = 1080;
+		RSS_WARN("could not determine sensor resolution; using %dx%d",
+			 sensor_w, sensor_h);
+	}
+	sensor_fps = read_sensor_proc_int(0, "max_fps", 10, 0);
+	if (sensor_fps <= 0)
+		sensor_fps = read_sensor_proc_int(0, "fps", 10, 0);
+	if (sensor_fps <= 0)
+		sensor_fps = 25;
+
+	load_stream_config(st->cfg, "stream0", stream, sensor_w, sensor_h, sensor_fps,
+			   8000000);
 	stream->fs_chn = 0;
 	stream->chn = 0;
 	stream->sensor_idx = 0;

--- a/tests/test_ctrl.c
+++ b/tests/test_ctrl.c
@@ -711,6 +711,21 @@ TEST get_sensor_fps_reports_live_and_base(void)
 	PASS();
 }
 
+/* V4L2 still owns an initialized ISP HAL for sensor tuning.  Its control
+ * guard must permit readback without admitting IMP encoder controls. */
+TEST get_sensor_fps_is_available_on_v4l2(void)
+{
+	sensor_fps_setup();
+	st.v4l2_backend = true;
+	setenv("RSS_MOCK_SENSOR_FPS_ACTUAL", "25", 1);
+	call("{\"cmd\":\"get-sensor-fps\"}");
+	unsetenv("RSS_MOCK_SENSOR_FPS_ACTUAL");
+	ASSERT(strstr(resp, "\"status\":\"ok\"") != NULL);
+	ASSERT(strstr(resp, "\"fps_num\":25") != NULL);
+	teardown();
+	PASS();
+}
+
 TEST set_qp_bounds_atomic_update(void)
 {
 	setup();
@@ -1225,6 +1240,7 @@ SUITE(ctrl_suite)
 	RUN_TEST(sensor_fps_sensor_reject_aborts_everything);
 	RUN_TEST(set_fps_clears_active_override);
 	RUN_TEST(get_sensor_fps_reports_live_and_base);
+	RUN_TEST(get_sensor_fps_is_available_on_v4l2);
 	RUN_TEST(set_qp_bounds_atomic_update);
 	RUN_TEST(set_qp_bounds_neither_updated_on_failure);
 	RUN_TEST(set_rc_mode_stores_enum_not_string);


### PR DESCRIPTION
## Summary

- initialize the ISP HAL and configured sensor before opening the standalone V4L2/OpenIMP path
- derive default resolution and cadence from the active `/proc/jz/sensor` registry entry instead of a fixed geometry
- keep encoder rate control, GOP, ring metadata, and downstream RTP on the measured native sensor rate
- allow `get-sensor-fps` through the V4L2 control guard while continuing to reject IMP graph controls

## Scope and ordering

The base V4L2/OpenIMP backend is already in `main`; this PR contains only the missing T31-compatible sensor startup and cadence corrections. It is independent of #32 and does not contain the RSD or RWD media-clock changes. It can merge independently, though reviewing #32 first keeps the clock work in its existing discussion.

## Validation

- host ASan/UBSan suite: 302 tests, 12,197 assertions, zero test failures
- T31 RVD cross-build with `V4L2_OPENIMP=1` and Raptor `-Werror` flags
- the same resulting RVD paths were exercised on a T31X integration build at 1920x1080/30 fps
