### PR TITLE
fix(rwd): preserve WebRTC video under backpressure

### DIFF
--- a/build-asan.sh
+++ b/build-asan.sh
@@ -322,7 +322,8 @@ $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_session.c" -
 $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_ring_reader.c" -o "$OUT/rsd_ring_reader.o"
 $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_sendq.c" -o "$OUT/rsd_sendq.o"
 $CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_backchannel.c" -o "$OUT/rsd_backchannel.o"
-$CC -o "$OUT/rsd" "$OUT"/rsd_main.o "$OUT"/rsd_server.o "$OUT"/rsd_session.o "$OUT"/rsd_ring_reader.o "$OUT"/rsd_sendq.o "$OUT"/rsd_backchannel.o $LIBS "$COMPY_BUILD/libcompy.a" $MBEDTLS_LIBS -lopus "$HELIX_BUILD/libhelix-aac.a" $LDFLAGS
+$CC $CFLAGS $COMPY_CFLAGS $RSD_CODEC_CFLAGS -c "$RAPTOR_DIR/rsd/rsd_media_clock.c" -o "$OUT/rsd_media_clock.o"
+$CC -o "$OUT/rsd" "$OUT"/rsd_main.o "$OUT"/rsd_server.o "$OUT"/rsd_session.o "$OUT"/rsd_ring_reader.o "$OUT"/rsd_sendq.o "$OUT"/rsd_backchannel.o "$OUT"/rsd_media_clock.o $LIBS "$COMPY_BUILD/libcompy.a" $MBEDTLS_LIBS -lopus "$HELIX_BUILD/libhelix-aac.a" $LDFLAGS
 echo "  -> rsd"
 
 echo "=== RIC ==="

--- a/build-asan.sh
+++ b/build-asan.sh
@@ -502,7 +502,7 @@ $CC $RWD_CFLAGS -c "$RAPTOR_DIR/rwd/rwd_media.c" -o "$OUT/rwd_media.o"
 $CC $RWD_CFLAGS -c "$RAPTOR_DIR/rwd/rwd_webtorrent.c" -o "$OUT/rwd_webtorrent.o"
 $CC -o "$OUT/rwd" "$OUT"/rwd_main.o "$OUT"/rwd_signaling.o "$OUT"/rwd_sdp.o \
     "$OUT"/rwd_ice.o "$OUT"/rwd_dtls.o "$OUT"/rwd_media.o "$OUT"/rwd_webtorrent.o \
-    $LIBS "$COMPY_BUILD/libcompy.a" $LIBS_TLS -lopus $LDFLAGS
+    "$OUT"/rsd_media_clock.o $LIBS "$COMPY_BUILD/libcompy.a" $LIBS_TLS -lopus $LDFLAGS
 echo "  -> rwd"
 
 echo "$SAN_LABEL" > "$STAMP"

--- a/rsd/Makefile
+++ b/rsd/Makefile
@@ -1,4 +1,4 @@
-SRCS := rsd_main.c rsd_server.c rsd_session.c rsd_ring_reader.c rsd_sendq.c rsd_backchannel.c
+SRCS := rsd_main.c rsd_server.c rsd_session.c rsd_ring_reader.c rsd_sendq.c rsd_backchannel.c rsd_media_clock.c
 OBJS := $(SRCS:.c=.o)
 BIN  := rsd
 

--- a/rsd/rsd_media_clock.c
+++ b/rsd/rsd_media_clock.c
@@ -1,0 +1,96 @@
+/*
+ * rsd_media_clock.c -- producer-to-monotonic video clock mapping
+ *
+ * IMP video timestamps follow CLOCK_MONOTONIC_RAW while sender reports use
+ * CLOCK_MONOTONIC. A fixed epoch offset therefore accumulates the frequency
+ * correction applied by ntpd. V4L2 timestamps may already be MONOTONIC, so
+ * the mapping must discover the relationship instead of assuming a domain.
+ *
+ * At the ring reader, now-media is the clock-domain offset plus non-negative
+ * delivery latency. The minimum observation is the best offset estimate.
+ * One minimum per second keeps an eight-second rolling window without a
+ * per-frame sample array. The estimate is then followed with the filtered
+ * proportional slew used by rad_clock: scheduler jitter cannot step the
+ * published timeline, while ordinary clock-frequency error cannot accumulate.
+ */
+
+#include "rsd_media_clock.h"
+
+#include <limits.h>
+
+#define RSD_MEDIA_CLOCK_BUCKET_US   1000000
+#define RSD_MEDIA_CLOCK_EWMA_DIV    16
+#define RSD_MEDIA_CLOCK_GAIN_DIV    16
+#define RSD_MEDIA_CLOCK_SLEW_MAX_US 1000
+
+static void clear_buckets(rsd_media_clock_t *clock)
+{
+	for (int i = 0; i < RSD_MEDIA_CLOCK_BUCKETS; i++)
+		clock->bucket_min_us[i] = INT64_MAX;
+}
+
+void rsd_media_clock_init(rsd_media_clock_t *clock)
+{
+	clear_buckets(clock);
+	clock->bucket_start_us = 0;
+	clock->offset_us = 0;
+	clock->err_ewma_us = 0;
+	clock->bucket = 0;
+	clock->initialized = false;
+}
+
+static void advance_window(rsd_media_clock_t *clock, int64_t now_us)
+{
+	int64_t elapsed = now_us - clock->bucket_start_us;
+	int64_t window_us = (int64_t)RSD_MEDIA_CLOCK_BUCKET_US * RSD_MEDIA_CLOCK_BUCKETS;
+
+	if (elapsed < 0 || elapsed >= window_us) {
+		clear_buckets(clock);
+		clock->bucket = 0;
+		clock->bucket_start_us = now_us;
+		return;
+	}
+
+	while (elapsed >= RSD_MEDIA_CLOCK_BUCKET_US) {
+		clock->bucket = (uint8_t)((clock->bucket + 1) % RSD_MEDIA_CLOCK_BUCKETS);
+		clock->bucket_min_us[clock->bucket] = INT64_MAX;
+		clock->bucket_start_us += RSD_MEDIA_CLOCK_BUCKET_US;
+		elapsed -= RSD_MEDIA_CLOCK_BUCKET_US;
+	}
+}
+
+int64_t rsd_media_clock_map(rsd_media_clock_t *clock, int64_t media_us, int64_t now_us)
+{
+	int64_t sample_us = now_us - media_us;
+
+	if (!clock->initialized) {
+		clock->bucket_start_us = now_us;
+		clock->bucket_min_us[0] = sample_us;
+		clock->offset_us = sample_us;
+		clock->initialized = true;
+		return media_us + clock->offset_us;
+	}
+
+	advance_window(clock, now_us);
+	if (sample_us < clock->bucket_min_us[clock->bucket])
+		clock->bucket_min_us[clock->bucket] = sample_us;
+
+	int64_t target_us = INT64_MAX;
+	for (int i = 0; i < RSD_MEDIA_CLOCK_BUCKETS; i++) {
+		if (clock->bucket_min_us[i] < target_us)
+			target_us = clock->bucket_min_us[i];
+	}
+
+	if (target_us != INT64_MAX) {
+		int64_t err_us = target_us - clock->offset_us;
+		clock->err_ewma_us += (err_us - clock->err_ewma_us) / RSD_MEDIA_CLOCK_EWMA_DIV;
+		int64_t slew_us = clock->err_ewma_us / RSD_MEDIA_CLOCK_GAIN_DIV;
+		if (slew_us > RSD_MEDIA_CLOCK_SLEW_MAX_US)
+			slew_us = RSD_MEDIA_CLOCK_SLEW_MAX_US;
+		else if (slew_us < -RSD_MEDIA_CLOCK_SLEW_MAX_US)
+			slew_us = -RSD_MEDIA_CLOCK_SLEW_MAX_US;
+		clock->offset_us += slew_us;
+	}
+
+	return media_us + clock->offset_us;
+}

--- a/rsd/rsd_media_clock.h
+++ b/rsd/rsd_media_clock.h
@@ -1,0 +1,41 @@
+/*
+ * rsd_media_clock.h -- map producer video timestamps to CLOCK_MONOTONIC
+ */
+
+#ifndef RSD_MEDIA_CLOCK_H
+#define RSD_MEDIA_CLOCK_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define RSD_MEDIA_CLOCK_BUCKETS 8
+
+typedef struct {
+	int64_t bucket_min_us[RSD_MEDIA_CLOCK_BUCKETS];
+	int64_t bucket_start_us;
+	int64_t offset_us;
+	int64_t err_ewma_us;
+	uint8_t bucket;
+	bool initialized;
+} rsd_media_clock_t;
+
+void rsd_media_clock_init(rsd_media_clock_t *clock);
+
+/*
+ * Map one producer timestamp into CLOCK_MONOTONIC. `now_us` is sampled
+ * after the frame reaches the ring reader, so now-media contains the
+ * clock-domain offset plus non-negative delivery and scheduling delay.
+ */
+int64_t rsd_media_clock_map(rsd_media_clock_t *clock, int64_t media_us, int64_t now_us);
+
+static inline bool rsd_media_clock_ready(const rsd_media_clock_t *clock)
+{
+	return clock->initialized;
+}
+
+static inline int64_t rsd_media_clock_offset(const rsd_media_clock_t *clock)
+{
+	return clock->offset_us;
+}
+
+#endif /* RSD_MEDIA_CLOCK_H */

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -14,6 +14,7 @@
 #include <pthread.h>
 
 #include "rsd.h"
+#include "rsd_media_clock.h"
 
 /* Forward declarations — called by send thread, defined below */
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
@@ -299,12 +300,12 @@ void *rsd_video_reader_thread(void *arg)
 	rsd_server_t *srv = rctx->srv;
 	int stream_idx = rctx->idx;
 
-	/* RTP cadence derives from the encoder timestamps. Their epoch is private
-	 * to the producer, so anchor the first fresh ring frame once to this
-	 * process's CLOCK_MONOTONIC for sender-report projection. */
+	/* RTP cadence derives from the encoder timestamps. Their epoch and clock
+	 * domain are private to the producer, so continuously map fresh ring frames
+	 * to CLOCK_MONOTONIC for sender-report projection. */
 	int64_t video_ts_epoch = 0;
-	int64_t video_mono_offset_us = 0;
-	bool video_mono_offset_set = false;
+	rsd_media_clock_t video_clock;
+	rsd_media_clock_init(&video_clock);
 	uint32_t last_rtp_ts = 0; /* enforce monotonic RTP timestamps */
 	bool has_last_rtp_ts = false;
 	uint64_t last_write_seq = 0;
@@ -348,8 +349,7 @@ void *rsd_video_reader_thread(void *arg)
 			last_write_seq = 0;
 			idle_count = 0;
 			video_ts_epoch = 0;
-			video_mono_offset_us = 0;
-			video_mono_offset_set = false;
+			rsd_media_clock_init(&video_clock);
 			last_rtp_ts = 0;
 			has_last_rtp_ts = false;
 			atomic_store_explicit(&rctx->vps_len, 0, memory_order_relaxed);
@@ -594,12 +594,13 @@ void *rsd_video_reader_thread(void *arg)
 			rctx->read_seq = read_seq;
 			total_read++;
 
-			if (!video_mono_offset_set) {
-				video_mono_offset_us = rss_timestamp_us() - (int64_t)meta.timestamp;
-				video_mono_offset_set = true;
-				RSS_INFO("video[%d] media->monotonic offset=%lld us", stream_idx,
-					 (long long)video_mono_offset_us);
-			}
+			bool first_clock_sample = !rsd_media_clock_ready(&video_clock);
+			int64_t capture_mono_us = rsd_media_clock_map(
+				&video_clock, (int64_t)meta.timestamp, rss_timestamp_us());
+			if (first_clock_sample)
+				RSS_INFO("video[%d] initial media->monotonic offset=%lld us",
+					 stream_idx,
+					 (long long)rsd_media_clock_offset(&video_clock));
 
 			if (video_ts_epoch == 0)
 				video_ts_epoch = meta.timestamp;
@@ -668,7 +669,6 @@ void *rsd_video_reader_thread(void *arg)
 				c->has_last_video_client_ts = true;
 
 				int qret;
-				int64_t capture_mono_us = meta.timestamp + video_mono_offset_us;
 				qret = rsd_sendq_push_video(&c->sendq, frame_data, length,
 							    client_ts, capture_mono_us, sei,
 							    sei_len, is_h265);

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -19,7 +19,7 @@
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
 				 uint32_t rtp_ts, int64_t capture_us);
 static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				uint32_t rtp_ts);
+				uint32_t rtp_ts, int64_t capture_us);
 
 /*
  * Minimum interval between IDR requests from the reader's lag-recovery
@@ -172,7 +172,7 @@ static void sendq_drain_audio(rsd_client_t *c)
  * large IDR frames from starving audio delivery.
  */
 static void rsd_send_video_interleaved(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				       uint32_t rtp_ts)
+				       uint32_t rtp_ts, int64_t capture_us)
 {
 	if (!c->video.nal || !c->video.playing)
 		return;
@@ -235,15 +235,20 @@ static void rsd_send_video_interleaved(rsd_client_t *c, const uint8_t *data, uin
 			sendq_drain_audio(c);
 	}
 
+	/* Pair the wire timestamp with the frame's capture instant before an
+	 * RTCP sender report projects it to now.  Using the network send time
+	 * here makes every five-second SR expose queue/Wi-Fi latency as a PTS
+	 * correction at the receiver. */
+	pthread_mutex_lock(&c->write_lock);
+	Compy_RtpTransport_set_clock_reference(c->video.rtp, rtp_ts, (uint64_t)capture_us);
 	if (c->srv->rtcp_sr) {
 		int64_t now = rss_timestamp_us();
 		if (c->video.rtcp && now - c->video.last_rtcp > RSD_SR_INTERVAL_US) {
-			pthread_mutex_lock(&c->write_lock);
 			(void)!Compy_Rtcp_send_sr(c->video.rtcp);
-			pthread_mutex_unlock(&c->write_lock);
 			c->video.last_rtcp = now;
 		}
 	}
+	pthread_mutex_unlock(&c->write_lock);
 }
 
 /* Per-client send thread — drains sendq through compy (blocking I/O) */
@@ -270,9 +275,11 @@ void *rsd_client_send_thread(void *arg)
 
 		if (entry.type == RSD_FRAME_VIDEO) {
 			if (c->video.jpeg)
-				rsd_send_jpeg_frame(c, entry.data, entry.len, entry.rtp_ts);
+				rsd_send_jpeg_frame(c, entry.data, entry.len, entry.rtp_ts,
+						    entry.capture_us);
 			else
-				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts);
+				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts,
+						       entry.capture_us);
 		} else {
 			pthread_mutex_lock(&c->write_lock);
 			rsd_send_audio_frame(c, entry.codec, entry.data, entry.len, entry.rtp_ts,
@@ -292,10 +299,12 @@ void *rsd_video_reader_thread(void *arg)
 	rsd_server_t *srv = rctx->srv;
 	int stream_idx = rctx->idx;
 
-	/* Wall-clock video timestamps: derive from IMP's CLOCK_MONOTONIC_RAW
-	 * timestamp, same clock source as audio. Both streams share the same
-	 * timebase so inter-stream drift is zero by construction. */
+	/* RTP cadence derives from the encoder timestamps. Their epoch is private
+	 * to the producer, so anchor the first fresh ring frame once to this
+	 * process's CLOCK_MONOTONIC for sender-report projection. */
 	int64_t video_ts_epoch = 0;
+	int64_t video_mono_offset_us = 0;
+	bool video_mono_offset_set = false;
 	uint32_t last_rtp_ts = 0; /* enforce monotonic RTP timestamps */
 	bool has_last_rtp_ts = false;
 	uint64_t last_write_seq = 0;
@@ -339,6 +348,8 @@ void *rsd_video_reader_thread(void *arg)
 			last_write_seq = 0;
 			idle_count = 0;
 			video_ts_epoch = 0;
+			video_mono_offset_us = 0;
+			video_mono_offset_set = false;
 			last_rtp_ts = 0;
 			has_last_rtp_ts = false;
 			atomic_store_explicit(&rctx->vps_len, 0, memory_order_relaxed);
@@ -583,6 +594,13 @@ void *rsd_video_reader_thread(void *arg)
 			rctx->read_seq = read_seq;
 			total_read++;
 
+			if (!video_mono_offset_set) {
+				video_mono_offset_us = rss_timestamp_us() - (int64_t)meta.timestamp;
+				video_mono_offset_set = true;
+				RSS_INFO("video[%d] media->monotonic offset=%lld us", stream_idx,
+					  (long long)video_mono_offset_us);
+			}
+
 			if (video_ts_epoch == 0)
 				video_ts_epoch = meta.timestamp;
 			uint32_t rtp_ts = (uint32_t)((uint64_t)(meta.timestamp - video_ts_epoch) *
@@ -650,8 +668,10 @@ void *rsd_video_reader_thread(void *arg)
 				c->has_last_video_client_ts = true;
 
 				int qret;
+				int64_t capture_mono_us = meta.timestamp + video_mono_offset_us;
 				qret = rsd_sendq_push_video(&c->sendq, frame_data, length,
-							    client_ts, sei, sei_len, is_h265);
+							    client_ts, capture_mono_us, sei, sei_len,
+							    is_h265);
 				if (qret == RSD_SENDQ_OK)
 					total_pushed++;
 				else if (qret == RSD_SENDQ_DROPPED) {
@@ -678,7 +698,8 @@ void *rsd_video_reader_thread(void *arg)
 
 /* ── JPEG send path (RFC 2435) ── */
 
-static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts)
+static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+				int64_t capture_us)
 {
 	if (!c->video.jpeg || !c->video.playing)
 		return;
@@ -686,17 +707,16 @@ static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t l
 	pthread_mutex_lock(&c->write_lock);
 	(void)!Compy_JpegTransport_send_frame(c->video.jpeg, Compy_RtpTimestamp_Raw(rtp_ts),
 					      U8Slice99_new((uint8_t *)data, len));
-	pthread_mutex_unlock(&c->write_lock);
+	Compy_RtpTransport_set_clock_reference(c->video.rtp, rtp_ts, (uint64_t)capture_us);
 
 	if (c->srv->rtcp_sr) {
 		int64_t now = rss_timestamp_us();
 		if (c->video.rtcp && now - c->video.last_rtcp > RSD_SR_INTERVAL_US) {
-			pthread_mutex_lock(&c->write_lock);
 			(void)!Compy_Rtcp_send_sr(c->video.rtcp);
-			pthread_mutex_unlock(&c->write_lock);
 			c->video.last_rtcp = now;
 		}
 	}
+	pthread_mutex_unlock(&c->write_lock);
 }
 
 /* ── Audio ring reader thread ── */

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -18,8 +18,8 @@
 /* Forward declarations — called by send thread, defined below */
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
 				 uint32_t rtp_ts, int64_t capture_us);
-static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len,
-				uint32_t rtp_ts, int64_t capture_us);
+static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+				int64_t capture_us);
 
 /*
  * Minimum interval between IDR requests from the reader's lag-recovery
@@ -279,7 +279,7 @@ void *rsd_client_send_thread(void *arg)
 						    entry.capture_us);
 			else
 				rsd_send_video_interleaved(c, entry.data, entry.len, entry.rtp_ts,
-						       entry.capture_us);
+							   entry.capture_us);
 		} else {
 			pthread_mutex_lock(&c->write_lock);
 			rsd_send_audio_frame(c, entry.codec, entry.data, entry.len, entry.rtp_ts,
@@ -598,7 +598,7 @@ void *rsd_video_reader_thread(void *arg)
 				video_mono_offset_us = rss_timestamp_us() - (int64_t)meta.timestamp;
 				video_mono_offset_set = true;
 				RSS_INFO("video[%d] media->monotonic offset=%lld us", stream_idx,
-					  (long long)video_mono_offset_us);
+					 (long long)video_mono_offset_us);
 			}
 
 			if (video_ts_epoch == 0)
@@ -670,8 +670,8 @@ void *rsd_video_reader_thread(void *arg)
 				int qret;
 				int64_t capture_mono_us = meta.timestamp + video_mono_offset_us;
 				qret = rsd_sendq_push_video(&c->sendq, frame_data, length,
-							    client_ts, capture_mono_us, sei, sei_len,
-							    is_h265);
+							    client_ts, capture_mono_us, sei,
+							    sei_len, is_h265);
 				if (qret == RSD_SENDQ_OK)
 					total_pushed++;
 				else if (qret == RSD_SENDQ_DROPPED) {

--- a/rsd/rsd_sendq.c
+++ b/rsd/rsd_sendq.c
@@ -149,7 +149,7 @@ static uint32_t first_vcl_offset(const uint8_t *data, uint32_t len, bool is_h265
  * before the first VCL NAL, after any in-band SPS/PPS.
  */
 int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-			 const uint8_t *sei, uint32_t sei_len, bool is_h265)
+			 int64_t capture_us, const uint8_t *sei, uint32_t sei_len, bool is_h265)
 {
 	uint8_t *copy = malloc((size_t)len + sei_len);
 	if (!copy)
@@ -184,6 +184,7 @@ int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint
 	slot->data = copy;
 	slot->len = len;
 	slot->rtp_ts = rtp_ts;
+	slot->capture_us = capture_us;
 	slot->type = RSD_FRAME_VIDEO;
 	slot->codec = 0;
 

--- a/rsd/rsd_sendq.h
+++ b/rsd/rsd_sendq.h
@@ -28,7 +28,7 @@ typedef struct {
 	const uint8_t *data; /* malloc'd copy or rmem pointer (zerocopy) */
 	uint32_t len;
 	uint32_t rtp_ts;
-	int64_t capture_us; /* ring capture instant (SR media-clock ref; audio only) */
+	int64_t capture_us; /* ring capture instant (RTCP SR media-clock reference) */
 	uint8_t type;	    /* RSD_FRAME_VIDEO or RSD_FRAME_AUDIO */
 	uint32_t codec;	    /* audio codec (RSD_FRAME_AUDIO only) */
 	bool zerocopy;	    /* true = rmem pointer, don't free */
@@ -66,7 +66,7 @@ void rsd_sendq_release_entry(rsd_sendq_entry_t *e);
 /* Caller holds q->lock. */
 bool rsd_sendq_take_audio_locked(rsd_sendq_t *q, rsd_sendq_entry_t *out);
 int rsd_sendq_push_video(rsd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-			 const uint8_t *sei, uint32_t sei_len, bool is_h265);
+			 int64_t capture_us, const uint8_t *sei, uint32_t sei_len, bool is_h265);
 int rsd_sendq_push_audio(rsd_sendq_t *q, uint32_t codec, const uint8_t *data, uint32_t len,
 			 uint32_t rtp_ts, int64_t capture_us);
 

--- a/rwd/Makefile
+++ b/rwd/Makefile
@@ -2,7 +2,7 @@ SRCS := rwd_main.c rwd_dtls.c rwd_ice.c rwd_sdp.c rwd_signaling.c rwd_media.c rw
 ifeq ($(WEBTORRENT),1)
 SRCS += rwd_webtorrent.c
 endif
-OBJS := $(SRCS:.c=.o)
+OBJS := $(SRCS:.c=.o) rsd_media_clock.o
 BIN  := rwd
 
 all: $(BIN)
@@ -12,6 +12,10 @@ $(BIN): $(OBJS)
 	$(Q)$(CC) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 %.o: %.c
+	@echo "  CC      $<"
+	$(Q)$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
+
+rsd_media_clock.o: ../rsd/rsd_media_clock.c ../rsd/rsd_media_clock.h
 	@echo "  CC      $<"
 	$(Q)$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 

--- a/rwd/rwd_main.c
+++ b/rwd/rwd_main.c
@@ -234,6 +234,32 @@ static int create_udp_socket(int port)
 	int reuse = 1;
 	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
 
+	/* One socket carries media for every WebRTC client.  A pair of 1080p
+	 * keyframes can exceed the kernel's small embedded default before Wi-Fi
+	 * drains it.  A lost FU-A fragment used to be invisible to RTP loss
+	 * accounting and left the decoder frozen until the next keyframe.
+	 *
+	 * Linux doubles SO_SNDBUF values internally, so 512 KiB requests a 1 MiB
+	 * queue.  RWD runs as root on the camera; SO_SNDBUFFORCE lets it obtain the
+	 * required queue without changing the system-wide wmem limit. */
+	int sndbuf = 512 * 1024;
+	int sndbuf_set = -1;
+#ifdef SO_SNDBUFFORCE
+	sndbuf_set = setsockopt(fd, SOL_SOCKET, SO_SNDBUFFORCE, &sndbuf, sizeof(sndbuf));
+#endif
+	if (sndbuf_set < 0)
+		sndbuf_set = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+
+	int actual_sndbuf = 0;
+	socklen_t actual_len = sizeof(actual_sndbuf);
+	if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &actual_sndbuf, &actual_len) == 0) {
+		if (sndbuf_set < 0 || actual_sndbuf < sndbuf * 2)
+			RSS_WARN("WebRTC UDP send buffer is %d bytes; requested %d", actual_sndbuf,
+				 sndbuf * 2);
+		else
+			RSS_DEBUG("WebRTC UDP send buffer: %d bytes", actual_sndbuf);
+	}
+
 	struct sockaddr_storage addr;
 	socklen_t addrlen = rss_sockaddr_any(family, (uint16_t)port, &addr);
 

--- a/rwd/rwd_media.c
+++ b/rwd/rwd_media.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <poll.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #ifdef RAPTOR_OPUS
@@ -37,6 +38,8 @@ typedef struct {
 	int fd;
 	struct sockaddr_storage addr;
 	socklen_t addr_len;
+	uint32_t backpressure_events;
+	int64_t last_backpressure_log_us;
 } RwdUdpSender;
 
 declImpl(Compy_Transport, RwdUdpSender);
@@ -50,8 +53,62 @@ static int RwdUdpSender_transmit(VSelf, Compy_IoVecSlice bufs)
 		.msg_iov = bufs.ptr,
 		.msg_iovlen = bufs.len,
 	};
-	ssize_t ret = sendmsg(self->fd, &msg, 0);
-	return ret >= 0 ? 0 : -1;
+	bool waited = false;
+	int64_t deadline_us = 0;
+
+	for (;;) {
+		ssize_t ret = sendmsg(self->fd, &msg, 0);
+		if (ret >= 0) {
+			if (waited) {
+				self->backpressure_events++;
+				int64_t now = rss_timestamp_us();
+				if (now - self->last_backpressure_log_us >= 5000000) {
+					RSS_DEBUG("media: UDP backpressure recovered (%u events)",
+						  self->backpressure_events);
+					self->backpressure_events = 0;
+					self->last_backpressure_log_us = now;
+				}
+			}
+			return 0;
+		}
+		if (errno == EINTR)
+			continue;
+		if (errno != EAGAIN && errno != EWOULDBLOCK && errno != ENOBUFS)
+			return -1;
+
+		/* The shared ICE socket is nonblocking because the main thread drains
+		 * inbound STUN/DTLS with recvfrom().  A large IDR can temporarily fill
+		 * its send queue; dropping one FU-A fragment here corrupts the access
+		 * unit without creating an RTP sequence gap, so the receiver cannot
+		 * report the loss.  Wait for one queue slot instead. */
+		int transient_errno = errno;
+		int64_t now = rss_timestamp_us();
+		if (!deadline_us)
+			deadline_us = now + 100000;
+		if (now >= deadline_us) {
+			errno = transient_errno;
+			return -1;
+		}
+		waited = true;
+
+		/* ENOBUFS is output-device backpressure rather than socket-buffer
+		 * pressure, so POLLOUT may remain asserted. Give the queue one tick. */
+		if (transient_errno == ENOBUFS) {
+			usleep(1000);
+			continue;
+		}
+
+		struct pollfd pfd = {.fd = self->fd, .events = POLLOUT};
+		int timeout_ms = (int)((deadline_us - now + 999) / 1000);
+		do {
+			ret = poll(&pfd, 1, timeout_ms);
+		} while (ret < 0 && errno == EINTR);
+		if (ret <= 0) {
+			if (ret == 0)
+				errno = transient_errno;
+			return -1;
+		}
+	}
 }
 
 static bool RwdUdpSender_is_full(VSelf)
@@ -447,11 +504,11 @@ static const uint8_t *find_nalu_end(const uint8_t *nalu_start, const uint8_t *en
 
 /* ── Parse Annex B and send NALUs via SRTP ── */
 
-static void rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t len,
-				 uint32_t rtp_ts, int64_t capture_us)
+static int rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t len,
+				uint32_t rtp_ts, int64_t capture_us)
 {
 	if (!c->nal_video || !c->sending)
-		return;
+		return 0;
 
 	const uint8_t *end = data + len;
 
@@ -492,9 +549,10 @@ static void rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t 
 		memcpy(stap + off, pps_data, pps_len);
 		off += pps_len;
 
-		(void)!Compy_RtpTransport_send_packet(c->rtp_video, Compy_RtpTimestamp_Raw(rtp_ts),
-						      false, U8Slice99_empty(),
-						      U8Slice99_new(stap, off));
+		if (Compy_RtpTransport_send_packet(c->rtp_video,
+						   Compy_RtpTimestamp_Raw(rtp_ts), false,
+						   U8Slice99_empty(), U8Slice99_new(stap, off)) < 0)
+			return -1;
 	}
 
 	/* Second pass: send picture NALUs (skip SPS/PPS) */
@@ -518,8 +576,9 @@ static void rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t 
 			.header = Compy_NalHeader_H264(Compy_H264NalHeader_parse(nalu_start[0])),
 			.payload = U8Slice99_new((uint8_t *)(nalu_start + 1), nalu_len - 1),
 		};
-		(void)!Compy_NalTransport_send_packet(c->nal_video, Compy_RtpTimestamp_Raw(rtp_ts),
-						      nalu);
+		if (Compy_NalTransport_send_packet(c->nal_video,
+						   Compy_RtpTimestamp_Raw(rtp_ts), nalu) < 0)
+			return -1;
 		p = nalu_end;
 	}
 
@@ -536,6 +595,7 @@ static void rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t 
 			c->last_rtcp_video = now;
 		}
 	}
+	return 0;
 }
 
 static void rwd_send_audio_frame(rwd_client_t *c, const uint8_t *data, uint32_t len,
@@ -568,8 +628,12 @@ static void *rwd_client_send_thread(void *arg)
 	rwd_sendq_entry_t e;
 
 	while (rwd_sendq_pop(&c->sendq, &e)) {
-		if (c->sending)
-			rwd_send_video_frame(c, e.data, e.len, e.rtp_ts, e.capture_us);
+		if (c->sending &&
+		    rwd_send_video_frame(c, e.data, e.len, e.rtp_ts, e.capture_us) < 0) {
+			rwd_sendq_fail(&c->sendq);
+			RSS_WARN("media: client[%s] UDP send stalled: waiting for keyframe",
+				 c->session_id);
+		}
 		free(e.data);
 	}
 	return NULL;
@@ -837,10 +901,11 @@ void *rwd_video_reader_thread(void *arg)
 				if (!c->send_thread_started)
 					continue;
 				if (rwd_sendq_push(&c->sendq, srv->video_bufs[s], length,
-						   client_ts, capture_mono_us) != 0) {
+						   client_ts, capture_mono_us, meta.is_key) != 0) {
 					/* Queue full: this client can't drain at
-					 * stream rate. Everything queued was purged;
-					 * resume clean at the next keyframe. */
+					 * stream rate, or its last access unit failed.
+					 * Everything queued was purged; resume clean
+					 * at the next keyframe. */
 					c->waiting_keyframe = true;
 					rwd_request_idr(srv, s);
 				}

--- a/rwd/rwd_media.c
+++ b/rwd/rwd_media.c
@@ -504,8 +504,8 @@ static const uint8_t *find_nalu_end(const uint8_t *nalu_start, const uint8_t *en
 
 /* ── Parse Annex B and send NALUs via SRTP ── */
 
-static int rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t len,
-				uint32_t rtp_ts, int64_t capture_us)
+static int rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+				int64_t capture_us)
 {
 	if (!c->nal_video || !c->sending)
 		return 0;
@@ -549,9 +549,9 @@ static int rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t l
 		memcpy(stap + off, pps_data, pps_len);
 		off += pps_len;
 
-		if (Compy_RtpTransport_send_packet(c->rtp_video,
-						   Compy_RtpTimestamp_Raw(rtp_ts), false,
-						   U8Slice99_empty(), U8Slice99_new(stap, off)) < 0)
+		if (Compy_RtpTransport_send_packet(c->rtp_video, Compy_RtpTimestamp_Raw(rtp_ts),
+						   false, U8Slice99_empty(),
+						   U8Slice99_new(stap, off)) < 0)
 			return -1;
 	}
 
@@ -576,8 +576,8 @@ static int rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t l
 			.header = Compy_NalHeader_H264(Compy_H264NalHeader_parse(nalu_start[0])),
 			.payload = U8Slice99_new((uint8_t *)(nalu_start + 1), nalu_len - 1),
 		};
-		if (Compy_NalTransport_send_packet(c->nal_video,
-						   Compy_RtpTimestamp_Raw(rtp_ts), nalu) < 0)
+		if (Compy_NalTransport_send_packet(c->nal_video, Compy_RtpTimestamp_Raw(rtp_ts),
+						   nalu) < 0)
 			return -1;
 		p = nalu_end;
 	}
@@ -900,8 +900,8 @@ void *rwd_video_reader_thread(void *arg)
 				uint32_t client_ts = rtp_ts - c->video_ts_offset;
 				if (!c->send_thread_started)
 					continue;
-				if (rwd_sendq_push(&c->sendq, srv->video_bufs[s], length,
-						   client_ts, capture_mono_us, meta.is_key) != 0) {
+				if (rwd_sendq_push(&c->sendq, srv->video_bufs[s], length, client_ts,
+						   capture_mono_us, meta.is_key) != 0) {
 					/* Queue full: this client can't drain at
 					 * stream rate, or its last access unit failed.
 					 * Everything queued was purged; resume clean

--- a/rwd/rwd_media.c
+++ b/rwd/rwd_media.c
@@ -22,6 +22,7 @@
 #endif
 
 #include "rwd.h"
+#include "../rsd/rsd_media_clock.h"
 
 /* Defined below the send helpers; spawned by rwd_media_setup. */
 static void *rwd_client_send_thread(void *arg);
@@ -447,7 +448,7 @@ static const uint8_t *find_nalu_end(const uint8_t *nalu_start, const uint8_t *en
 /* ── Parse Annex B and send NALUs via SRTP ── */
 
 static void rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t len,
-				 uint32_t rtp_ts)
+				 uint32_t rtp_ts, int64_t capture_us)
 {
 	if (!c->nal_video || !c->sending)
 		return;
@@ -522,6 +523,11 @@ static void rwd_send_video_frame(rwd_client_t *c, const uint8_t *data, uint32_t 
 		p = nalu_end;
 	}
 
+	/* Pair the wire timestamp with the frame's capture instant before an
+	 * RTCP sender report projects it to now. Using the network send time here
+	 * makes queue/Wi-Fi latency appear as a clock correction at the browser. */
+	Compy_RtpTransport_set_clock_reference(c->rtp_video, rtp_ts, (uint64_t)capture_us);
+
 	/* Periodic RTCP SR (every 5 seconds) */
 	if (c->rtcp_video) {
 		int64_t now = rss_timestamp_us();
@@ -563,7 +569,7 @@ static void *rwd_client_send_thread(void *arg)
 
 	while (rwd_sendq_pop(&c->sendq, &e)) {
 		if (c->sending)
-			rwd_send_video_frame(c, e.data, e.len, e.rtp_ts);
+			rwd_send_video_frame(c, e.data, e.len, e.rtp_ts, e.capture_us);
 		free(e.data);
 	}
 	return NULL;
@@ -581,6 +587,10 @@ void *rwd_video_reader_thread(void *arg)
 {
 	rwd_server_t *srv = arg;
 	int64_t video_ts_epoch[RWD_STREAM_COUNT] = {0};
+	rsd_media_clock_t video_clock[RWD_STREAM_COUNT];
+	bool stream_active[RWD_STREAM_COUNT] = {false};
+	for (int s = 0; s < RWD_STREAM_COUNT; s++)
+		rsd_media_clock_init(&video_clock[s]);
 
 	/* Wait for at least the main ring */
 	while (rss_running(srv->running) && !srv->video_rings[0]) {
@@ -654,6 +664,7 @@ void *rwd_video_reader_thread(void *arg)
 					last_ws[s] = 0;
 					idle[s] = 0;
 					video_ts_epoch[s] = 0;
+					rsd_media_clock_init(&video_clock[s]);
 
 					/* Detect codec change — disconnect clients
 					 * if codec switched (WebRTC can't renegotiate
@@ -698,8 +709,14 @@ void *rwd_video_reader_thread(void *arg)
 				}
 			}
 			pthread_mutex_unlock(&srv->clients_lock);
-			if (!has_clients)
+			if (!has_clients) {
+				stream_active[s] = false;
 				continue;
+			}
+			if (!stream_active[s]) {
+				rsd_media_clock_init(&video_clock[s]);
+				stream_active[s] = true;
+			}
 
 			any_polled = true;
 			int ret = rss_ring_wait(srv->video_rings[s], 50);
@@ -780,6 +797,8 @@ void *rwd_video_reader_thread(void *arg)
 				continue;
 
 			srv->video_read_seq[s] = read_seq;
+			int64_t capture_mono_us = rsd_media_clock_map(
+				&video_clock[s], (int64_t)meta.timestamp, rss_timestamp_us());
 
 			if (video_ts_epoch[s] == 0)
 				video_ts_epoch[s] = meta.timestamp;
@@ -810,7 +829,7 @@ void *rwd_video_reader_thread(void *arg)
 				if (!c->send_thread_started)
 					continue;
 				if (rwd_sendq_push(&c->sendq, srv->video_bufs[s], length,
-						   client_ts) != 0) {
+						   client_ts, capture_mono_us) != 0) {
 					/* Queue full: this client can't drain at
 					 * stream rate. Everything queued was purged;
 					 * resume clean at the next keyframe. */

--- a/rwd/rwd_media.c
+++ b/rwd/rwd_media.c
@@ -719,7 +719,16 @@ void *rwd_video_reader_thread(void *arg)
 			}
 
 			any_polled = true;
-			int ret = rss_ring_wait(srv->video_rings[s], 50);
+			uint64_t read_seq = srv->video_read_seq[s];
+			const rss_ring_header_t *wait_hdr =
+				rss_ring_get_header(srv->video_rings[s]);
+			int ret = 0;
+			/* write_seq itself is a complete readable frame. Wait only when
+			 * read_seq is already beyond it; otherwise drain queued frames.
+			 * Always waiting for the next publish makes transient scheduler or
+			 * send delay permanent until the ten-frame skip forces a freeze. */
+			if (wait_hdr->write_seq < read_seq)
+				ret = rss_ring_wait(srv->video_rings[s], 50);
 			if (ret != 0) {
 				const rss_ring_header_t *h =
 					rss_ring_get_header(srv->video_rings[s]);
@@ -742,7 +751,6 @@ void *rwd_video_reader_thread(void *arg)
 
 			uint32_t length;
 			rss_ring_slot_t meta;
-			uint64_t read_seq = srv->video_read_seq[s];
 
 			/* Skip to latest when lag exceeds 10 frames.
 			 * Small lags (2-3 frames on slower SoCs) are read

--- a/rwd/rwd_sendq.c
+++ b/rwd/rwd_sendq.c
@@ -25,7 +25,8 @@ static void purge_locked(rwd_sendq_t *q)
 	}
 }
 
-int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts)
+int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+		   int64_t capture_us)
 {
 	uint8_t *copy = malloc(len);
 	if (!copy)
@@ -52,6 +53,7 @@ int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t r
 	slot->data = copy;
 	slot->len = len;
 	slot->rtp_ts = rtp_ts;
+	slot->capture_us = capture_us;
 	q->head = (q->head + 1) % RWD_SENDQ_SLOTS;
 	q->count++;
 	pthread_cond_signal(&q->cond);

--- a/rwd/rwd_sendq.c
+++ b/rwd/rwd_sendq.c
@@ -25,12 +25,25 @@ static void purge_locked(rwd_sendq_t *q)
 	}
 }
 
+void rwd_sendq_fail(rwd_sendq_t *q)
+{
+	pthread_mutex_lock(&q->lock);
+	if (!q->shutdown) {
+		purge_locked(q);
+		q->needs_keyframe = true;
+		q->drops++; /* failed in-flight frame */
+	}
+	pthread_mutex_unlock(&q->lock);
+}
+
 int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-		   int64_t capture_us)
+		   int64_t capture_us, bool is_key)
 {
 	uint8_t *copy = malloc(len);
-	if (!copy)
+	if (!copy) {
+		rwd_sendq_fail(q);
 		return -1;
+	}
 	memcpy(copy, data, len);
 
 	pthread_mutex_lock(&q->lock);
@@ -39,11 +52,20 @@ int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t r
 		free(copy);
 		return -1;
 	}
+	if (q->needs_keyframe) {
+		if (!is_key) {
+			pthread_mutex_unlock(&q->lock);
+			free(copy);
+			return 1;
+		}
+		q->needs_keyframe = false;
+	}
 	if (q->count >= RWD_SENDQ_SLOTS) {
 		/* The client can't drain at stream rate. Keeping a stale
 		 * backlog only adds latency; drop everything and let the
 		 * caller resume clean at the next keyframe. */
 		purge_locked(q);
+		q->needs_keyframe = true;
 		q->drops++; /* the incoming frame */
 		pthread_mutex_unlock(&q->lock);
 		free(copy);

--- a/rwd/rwd_sendq.h
+++ b/rwd/rwd_sendq.h
@@ -26,6 +26,7 @@ typedef struct {
 	uint8_t *data; /* malloc'd copy */
 	uint32_t len;
 	uint32_t rtp_ts;
+	int64_t capture_us;
 } rwd_sendq_entry_t;
 
 typedef struct {
@@ -44,7 +45,8 @@ void rwd_sendq_init(rwd_sendq_t *q);
 /* Copy a frame in. Returns 0 on success; 1 if the queue was full (all
  * queued video purged, caller should re-arm waiting-for-keyframe and
  * request an IDR); -1 on allocation failure (treat like 1). */
-int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts);
+int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
+		   int64_t capture_us);
 
 /* Blocking pop. Returns false when the queue is shut down; entries
  * still queued at shutdown are freed by rwd_sendq_destroy, not

--- a/rwd/rwd_sendq.h
+++ b/rwd/rwd_sendq.h
@@ -35,6 +35,7 @@ typedef struct {
 	int tail; /* next pop slot */
 	int count;
 	bool shutdown;
+	bool needs_keyframe;
 	uint64_t drops; /* frames purged by overflow */
 	pthread_mutex_t lock;
 	pthread_cond_t cond;
@@ -42,16 +43,22 @@ typedef struct {
 
 void rwd_sendq_init(rwd_sendq_t *q);
 
-/* Copy a frame in. Returns 0 on success; 1 if the queue was full (all
- * queued video purged, caller should re-arm waiting-for-keyframe and
- * request an IDR); -1 on allocation failure (treat like 1). */
+/* Copy a frame in. Returns 0 on success; 1 while recovery requires a
+ * keyframe or when the queue was purged; -1 on allocation/shutdown.
+ * The caller should re-arm waiting-for-keyframe and request an IDR for
+ * either nonzero result. */
 int rwd_sendq_push(rwd_sendq_t *q, const uint8_t *data, uint32_t len, uint32_t rtp_ts,
-		   int64_t capture_us);
+		   int64_t capture_us, bool is_key);
 
 /* Blocking pop. Returns false when the queue is shut down; entries
  * still queued at shutdown are freed by rwd_sendq_destroy, not
  * delivered. Caller frees out->data after sending. */
 bool rwd_sendq_pop(rwd_sendq_t *q, rwd_sendq_entry_t *out);
+
+/* Purge frames queued behind a failed access unit and refuse inter
+ * frames until the reader supplies a keyframe. Safe from the send
+ * thread while the ring reader is pushing. */
+void rwd_sendq_fail(rwd_sendq_t *q);
 
 /* Wake the popper and make it exit; push becomes a no-op. */
 void rwd_sendq_shutdown(rwd_sendq_t *q);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,9 +21,9 @@ CFLAGS = -Wall -Wextra -std=$(RAPTOR_STD) -D_GNU_SOURCE -g $(SAN_FLAGS) $(RAPTOR
 LDFLAGS = $(SAN_FLAGS) -lpthread -lrt -lm
 
 TEST_SRCS = main.c test_ric_json.c test_nal.c test_prebuf.c test_mux.c test_codec.c test_sdp.c test_ring.c test_rsp.c \
-            test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rad_clock.c test_media_clock.c test_resync.c \
+            test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rwd_sendq.c test_rad_clock.c test_media_clock.c test_resync.c \
             test_backchannel.c test_config.c
-LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rsd/rsd_media_clock.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
+LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rsd/rsd_media_clock.c ../rwd/rwd_sendq.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
            ../../raptor-common/src/rss_util.c ../../raptor-common/src/rss_log.c \
            ../../raptor-common/src/cJSON.c \
            ../../raptor-common/third_party/monocypher/monocypher.c \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,9 +21,9 @@ CFLAGS = -Wall -Wextra -std=$(RAPTOR_STD) -D_GNU_SOURCE -g $(SAN_FLAGS) $(RAPTOR
 LDFLAGS = $(SAN_FLAGS) -lpthread -lrt -lm
 
 TEST_SRCS = main.c test_ric_json.c test_nal.c test_prebuf.c test_mux.c test_codec.c test_sdp.c test_ring.c test_rsp.c \
-            test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rad_clock.c test_resync.c \
+            test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rad_clock.c test_media_clock.c test_resync.c \
             test_backchannel.c test_config.c
-LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
+LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rsd/rsd_media_clock.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
            ../../raptor-common/src/rss_util.c ../../raptor-common/src/rss_log.c \
            ../../raptor-common/src/cJSON.c \
            ../../raptor-common/third_party/monocypher/monocypher.c \

--- a/tests/main.c
+++ b/tests/main.c
@@ -20,6 +20,7 @@ extern SUITE(storage_suite);
 extern SUITE(timelapse_suite);
 extern SUITE(sendq_suite);
 extern SUITE(rad_clock_suite);
+extern SUITE(media_clock_suite);
 extern SUITE(resync_suite);
 extern SUITE(backchannel_suite);
 extern SUITE(config_suite);
@@ -49,6 +50,7 @@ int main(int argc, char **argv)
 	RUN_SUITE(timelapse_suite);
 	RUN_SUITE(sendq_suite);
 	RUN_SUITE(rad_clock_suite);
+	RUN_SUITE(media_clock_suite);
 	RUN_SUITE(resync_suite);
 	RUN_SUITE(backchannel_suite);
 	RUN_SUITE(config_suite);

--- a/tests/main.c
+++ b/tests/main.c
@@ -19,6 +19,7 @@ extern SUITE(sign_suite);
 extern SUITE(storage_suite);
 extern SUITE(timelapse_suite);
 extern SUITE(sendq_suite);
+extern SUITE(rwd_sendq_suite);
 extern SUITE(rad_clock_suite);
 extern SUITE(media_clock_suite);
 extern SUITE(resync_suite);
@@ -49,6 +50,7 @@ int main(int argc, char **argv)
 	RUN_SUITE(storage_suite);
 	RUN_SUITE(timelapse_suite);
 	RUN_SUITE(sendq_suite);
+	RUN_SUITE(rwd_sendq_suite);
 	RUN_SUITE(rad_clock_suite);
 	RUN_SUITE(media_clock_suite);
 	RUN_SUITE(resync_suite);

--- a/tests/test_media_clock.c
+++ b/tests/test_media_clock.c
@@ -1,0 +1,100 @@
+/*
+ * test_media_clock.c -- producer video timestamp mapping
+ */
+
+#include "greatest.h"
+#include "../rsd/rsd_media_clock.h"
+
+#define FRAME_US 40000
+
+static int64_t abs64(int64_t value)
+{
+	return value < 0 ? -value : value;
+}
+
+/* CLOCK_MONOTONIC runs 300 ppm faster than the producer's RAW clock.
+ * A frozen epoch loses 54 ms over this run; the tracker must instead
+ * reproduce wall-clock rate after its rolling-minimum warmup. */
+TEST media_clock_tracks_positive_domain_drift(void)
+{
+	rsd_media_clock_t clock;
+	rsd_media_clock_init(&clock);
+
+	int64_t media_us = 1000000;
+	int64_t wall_us = 2000000;
+	int64_t warm_err = 0;
+	int64_t final_err = 0;
+
+	for (int i = 0; i < 4500; i++) { /* 180 s at 25 fps */
+		media_us += FRAME_US;
+		wall_us += FRAME_US + 12; /* +300 ppm */
+		int64_t latency_us = 2000 + (i % 7) * 37;
+		if (i % 113 == 0)
+			latency_us += 20000;
+		int64_t mapped_us = rsd_media_clock_map(&clock, media_us, wall_us + latency_us);
+		if (i == 1499)
+			warm_err = mapped_us - wall_us;
+		if (i == 4499)
+			final_err = mapped_us - wall_us;
+	}
+
+	ASSERT(abs64(final_err) < 5000);
+	ASSERT(abs64(final_err - warm_err) < 2000);
+	PASS();
+}
+
+/* V4L2 timestamps are already CLOCK_MONOTONIC. Reader latency is a
+ * non-negative contaminant, so isolated stalls must not move the mapping. */
+TEST media_clock_rejects_reader_latency_spikes(void)
+{
+	rsd_media_clock_t clock;
+	rsd_media_clock_init(&clock);
+
+	int64_t media_us = 1000000;
+	int64_t previous_offset = 0;
+	for (int i = 0; i < 1500; i++) {
+		media_us += FRAME_US;
+		int64_t latency_us = 1800 + (i % 5) * 20;
+		if (i > 0 && i % 97 == 0)
+			latency_us += 100000;
+		rsd_media_clock_map(&clock, media_us, media_us + latency_us);
+		int64_t offset = rsd_media_clock_offset(&clock);
+		if (i > 0)
+			ASSERT(abs64(offset - previous_offset) <= 1000);
+		previous_offset = offset;
+	}
+
+	ASSERT(rsd_media_clock_offset(&clock) >= 1750);
+	ASSERT(rsd_media_clock_offset(&clock) <= 2500);
+	PASS();
+}
+
+/* A rising domain offset must age the old minimum out of the window.
+ * The correction may move only by the advertised per-frame authority. */
+TEST media_clock_ages_minimum_with_bounded_slew(void)
+{
+	rsd_media_clock_t clock;
+	rsd_media_clock_init(&clock);
+
+	int64_t media_us = 1000000;
+	int64_t previous_offset = 0;
+	for (int i = 0; i < 750; i++) {
+		media_us += FRAME_US;
+		int64_t domain_offset = i < 250 ? 1000 : 21000;
+		rsd_media_clock_map(&clock, media_us, media_us + domain_offset + 1000);
+		int64_t offset = rsd_media_clock_offset(&clock);
+		if (i > 0)
+			ASSERT(abs64(offset - previous_offset) <= 1000);
+		previous_offset = offset;
+	}
+
+	ASSERT(rsd_media_clock_offset(&clock) > 18000);
+	PASS();
+}
+
+SUITE(media_clock_suite)
+{
+	RUN_TEST(media_clock_tracks_positive_domain_drift);
+	RUN_TEST(media_clock_rejects_reader_latency_spikes);
+	RUN_TEST(media_clock_ages_minimum_with_bounded_slew);
+}

--- a/tests/test_rwd_sendq.c
+++ b/tests/test_rwd_sendq.c
@@ -1,0 +1,78 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "greatest.h"
+#include "../rwd/rwd_sendq.h"
+
+static const uint8_t frame[] = {0x00, 0x00, 0x00, 0x01, 0x65};
+
+TEST rwd_sendq_preserves_capture_reference(void)
+{
+	rwd_sendq_t q;
+	rwd_sendq_entry_t entry;
+
+	rwd_sendq_init(&q);
+	ASSERT_EQ(0, rwd_sendq_push(&q, frame, sizeof(frame), 9000, 1234567, true));
+	ASSERT(rwd_sendq_pop(&q, &entry));
+	ASSERT_EQ(sizeof(frame), entry.len);
+	ASSERT_EQ(9000, entry.rtp_ts);
+	ASSERT_EQ(1234567, entry.capture_us);
+	ASSERT_EQ(0, memcmp(frame, entry.data, sizeof(frame)));
+	free(entry.data);
+	rwd_sendq_destroy(&q);
+	PASS();
+}
+
+TEST rwd_sendq_failure_resumes_only_on_keyframe(void)
+{
+	rwd_sendq_t q;
+	rwd_sendq_entry_t entry;
+
+	rwd_sendq_init(&q);
+	ASSERT_EQ(0, rwd_sendq_push(&q, frame, sizeof(frame), 9000, 1000, true));
+	ASSERT(rwd_sendq_pop(&q, &entry));
+	free(entry.data);
+	ASSERT_EQ(0, rwd_sendq_push(&q, frame, sizeof(frame), 12000, 2000, false));
+
+	rwd_sendq_fail(&q);
+	ASSERT_EQ(0, q.count);
+	ASSERT(q.needs_keyframe);
+	ASSERT_EQ(1, rwd_sendq_push(&q, frame, sizeof(frame), 15000, 3000, false));
+	ASSERT_EQ(0, q.count);
+	ASSERT_EQ(0, rwd_sendq_push(&q, frame, sizeof(frame), 18000, 4000, true));
+	ASSERT_FALSE(q.needs_keyframe);
+	ASSERT(rwd_sendq_pop(&q, &entry));
+	ASSERT_EQ(18000, entry.rtp_ts);
+	free(entry.data);
+	rwd_sendq_destroy(&q);
+	PASS();
+}
+
+TEST rwd_sendq_overflow_purges_backlog(void)
+{
+	rwd_sendq_t q;
+	rwd_sendq_entry_t entry;
+
+	rwd_sendq_init(&q);
+	for (int i = 0; i < RWD_SENDQ_SLOTS; i++)
+		ASSERT_EQ(0, rwd_sendq_push(&q, frame, sizeof(frame), (uint32_t)i, i, true));
+	ASSERT_EQ(RWD_SENDQ_SLOTS, q.count);
+	ASSERT_EQ(1, rwd_sendq_push(&q, frame, sizeof(frame), 100, 100, false));
+	ASSERT_EQ(0, q.count);
+	ASSERT(q.needs_keyframe);
+	ASSERT_EQ(1, rwd_sendq_push(&q, frame, sizeof(frame), 101, 101, false));
+	ASSERT_EQ(0, rwd_sendq_push(&q, frame, sizeof(frame), 102, 102, true));
+	ASSERT(rwd_sendq_pop(&q, &entry));
+	ASSERT_EQ(102, entry.rtp_ts);
+	free(entry.data);
+	rwd_sendq_destroy(&q);
+	PASS();
+}
+
+SUITE(rwd_sendq_suite)
+{
+	RUN_TEST(rwd_sendq_preserves_capture_reference);
+	RUN_TEST(rwd_sendq_failure_resumes_only_on_keyframe);
+	RUN_TEST(rwd_sendq_overflow_purges_backlog);
+}

--- a/tests/test_sendq.c
+++ b/tests/test_sendq.c
@@ -24,7 +24,8 @@ static int push_a(rsd_sendq_t *q, uint32_t ts)
 
 static int push_v(rsd_sendq_t *q, uint32_t ts)
 {
-	return rsd_sendq_push_video(q, payload, sizeof(payload), ts, NULL, 0, false);
+	return rsd_sendq_push_video(q, payload, sizeof(payload), ts, (int64_t)ts * 100, NULL, 0,
+				    false);
 }
 
 /* Walk the queue oldest-first, collecting (type, ts) into arrays. */
@@ -55,6 +56,7 @@ TEST push_pop_order_preserved(void)
 	ASSERT_EQ(4, snapshot(&q, types, ts, 8));
 	ASSERT_EQ(RSD_FRAME_VIDEO, types[0]);
 	ASSERT_EQ(100u, ts[0]);
+	ASSERT_EQ(10000, q.entries[q.tail].capture_us);
 	ASSERT_EQ(RSD_FRAME_AUDIO, types[1]);
 	ASSERT_EQ(101u, ts[1]);
 	ASSERT_EQ(RSD_FRAME_VIDEO, types[2]);
@@ -229,11 +231,13 @@ TEST sei_spliced_before_first_vcl(void)
 	static const uint8_t sei[] = {0, 0, 0, 1, 0x06, 0x05, 0x02, 0xde, 0xad};
 
 	ASSERT_EQ(RSD_SENDQ_OK,
-		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, sei, sizeof(sei), false));
+		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, 1234567, sei, sizeof(sei),
+					 false));
 	ASSERT_EQ(1, q.count);
 
 	const rsd_sendq_entry_t *e = &q.entries[q.tail];
 	ASSERT_EQ(sizeof(frame) + sizeof(sei), e->len);
+	ASSERT_EQ(1234567, e->capture_us);
 	/* SPS first (start code + 2 bytes), then the SEI, then the IDR. */
 	ASSERT_EQ(0, memcmp(e->data, frame, 6));
 	ASSERT_EQ(0, memcmp(e->data + 6, sei, sizeof(sei)));

--- a/tests/test_sendq.c
+++ b/tests/test_sendq.c
@@ -230,9 +230,8 @@ TEST sei_spliced_before_first_vcl(void)
 	static const uint8_t frame[] = {0, 0, 0, 1, 0x67, 0x42, 0, 0, 0, 1, 0x65, 0x88};
 	static const uint8_t sei[] = {0, 0, 0, 1, 0x06, 0x05, 0x02, 0xde, 0xad};
 
-	ASSERT_EQ(RSD_SENDQ_OK,
-		  rsd_sendq_push_video(&q, frame, sizeof(frame), 77, 1234567, sei, sizeof(sei),
-					 false));
+	ASSERT_EQ(RSD_SENDQ_OK, rsd_sendq_push_video(&q, frame, sizeof(frame), 77, 1234567, sei,
+						     sizeof(sei), false));
 	ASSERT_EQ(1, q.count);
 
 	const rsd_sendq_entry_t *e = &q.entries[q.tail];


### PR DESCRIPTION
Depends on #32.

This PR deliberately carries the exact #32 media-clock commits because RWD reuses rsd_media_clock. After #32 merges, the remaining review is only the RWD queue/backpressure delta. It does not include the V4L2 sensor-startup work, which is isolated in #33.

Changes:
- anchor video RTCP sender reports to capture time through the continuously tracked media clock from #32
- drain already queued video before waiting for new ring data
- retry transient UDP EAGAIN/ENOBUFS with a bounded wait and request a 1 MiB send buffer
- propagate packetization/send failures, purge the failed access unit, and resume only on a keyframe
- add focused queue recovery/overflow coverage

Validation:
- host suite: 307 tests, 14,507 assertions, 0 test failures
- direct T31 RWD cross-build with project -Werror
- the identical production source tree ran a 107.3 s 1920x1080/30 WebRTC test: 3,213 decoded frames, zero lost/dropped/PLI/NACK/FIR, only the initial 0.262 s startup freeze, and zero UDP SndbufErrors