### PR TITLE
rvd: expose OpenIMP V4L2 runtime controls

### DIFF
--- a/rvd/rvd.h
+++ b/rvd/rvd.h
@@ -34,6 +34,8 @@ typedef rss_v4l2_h264_t rvd_v4l2_h264_t;
 #define rvd_v4l2_h264_request_idr   rss_v4l2_h264_request_idr
 #define rvd_v4l2_h264_set_bitrate   rss_v4l2_h264_set_bitrate
 #define rvd_v4l2_h264_get_bitrate   rss_v4l2_h264_get_bitrate
+#define rvd_v4l2_h264_set_gop       rss_v4l2_h264_set_gop
+#define rvd_v4l2_h264_get_gop       rss_v4l2_h264_get_gop
 static inline bool rvd_v4l2_h264_supported(void)
 {
 	return true;
@@ -101,6 +103,18 @@ static inline int rvd_v4l2_h264_get_bitrate(rvd_v4l2_h264_t *backend, uint32_t *
 	(void)backend;
 	(void)target_bitrate;
 	(void)average_bitrate;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_set_gop(rvd_v4l2_h264_t *backend, uint32_t gop_length)
+{
+	(void)backend;
+	(void)gop_length;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_get_gop(rvd_v4l2_h264_t *backend, uint32_t *gop_length)
+{
+	(void)backend;
+	(void)gop_length;
 	return RSS_ERR_NOTSUP;
 }
 #endif

--- a/rvd/rvd.h
+++ b/rvd/rvd.h
@@ -34,8 +34,8 @@ typedef rss_v4l2_h264_t rvd_v4l2_h264_t;
 #define rvd_v4l2_h264_request_idr   rss_v4l2_h264_request_idr
 #define rvd_v4l2_h264_set_bitrate   rss_v4l2_h264_set_bitrate
 #define rvd_v4l2_h264_get_bitrate   rss_v4l2_h264_get_bitrate
-#define rvd_v4l2_h264_set_gop       rss_v4l2_h264_set_gop
-#define rvd_v4l2_h264_get_gop       rss_v4l2_h264_get_gop
+#define rvd_v4l2_h264_set_gop	    rss_v4l2_h264_set_gop
+#define rvd_v4l2_h264_get_gop	    rss_v4l2_h264_get_gop
 static inline bool rvd_v4l2_h264_supported(void)
 {
 	return true;

--- a/rvd/rvd.h
+++ b/rvd/rvd.h
@@ -32,6 +32,8 @@ typedef rss_v4l2_h264_t rvd_v4l2_h264_t;
 #define rvd_v4l2_h264_get_frame	    rss_v4l2_h264_get_frame
 #define rvd_v4l2_h264_release_frame rss_v4l2_h264_release_frame
 #define rvd_v4l2_h264_request_idr   rss_v4l2_h264_request_idr
+#define rvd_v4l2_h264_set_bitrate   rss_v4l2_h264_set_bitrate
+#define rvd_v4l2_h264_get_bitrate   rss_v4l2_h264_get_bitrate
 static inline bool rvd_v4l2_h264_supported(void)
 {
 	return true;
@@ -85,6 +87,21 @@ static inline int rvd_v4l2_h264_release_frame(rvd_v4l2_h264_t *backend, rss_fram
 static inline int rvd_v4l2_h264_request_idr(rvd_v4l2_h264_t *backend)
 {
 	(void)backend;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_set_bitrate(rvd_v4l2_h264_t *backend, uint32_t bitrate)
+{
+	(void)backend;
+	(void)bitrate;
+	return RSS_ERR_NOTSUP;
+}
+static inline int rvd_v4l2_h264_get_bitrate(rvd_v4l2_h264_t *backend,
+					    uint32_t *target_bitrate,
+					    uint32_t *average_bitrate)
+{
+	(void)backend;
+	(void)target_bitrate;
+	(void)average_bitrate;
 	return RSS_ERR_NOTSUP;
 }
 #endif

--- a/rvd/rvd.h
+++ b/rvd/rvd.h
@@ -95,8 +95,7 @@ static inline int rvd_v4l2_h264_set_bitrate(rvd_v4l2_h264_t *backend, uint32_t b
 	(void)bitrate;
 	return RSS_ERR_NOTSUP;
 }
-static inline int rvd_v4l2_h264_get_bitrate(rvd_v4l2_h264_t *backend,
-					    uint32_t *target_bitrate,
+static inline int rvd_v4l2_h264_get_bitrate(rvd_v4l2_h264_t *backend, uint32_t *target_bitrate,
 					    uint32_t *average_bitrate)
 {
 	(void)backend;

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -246,9 +246,13 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 	if (strcmp(cmd, "set-bitrate") == 0) {
 		if (rss_json_get_int(cmd_json, "channel", &chn) == 0 &&
 		    rss_json_get_int(cmd_json, "value", &val) == 0 && chn >= 0 &&
-		    chn < st->stream_count) {
-			int ret = RSS_HAL_CALL(st->ops, enc_set_bitrate, st->hal_ctx,
-					       st->streams[chn].chn, val);
+		    chn < st->stream_count && val > 0) {
+			int ret;
+			if (st->v4l2_backend)
+				ret = rvd_v4l2_h264_set_bitrate(st->v4l2, (uint32_t)val);
+			else
+				ret = RSS_HAL_CALL(st->ops, enc_set_bitrate, st->hal_ctx,
+						   st->streams[chn].chn, val);
 			const char *key = rvd_persist_key(&st->streams[chn], "bitrate");
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.bitrate = val;
@@ -258,7 +262,7 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 			}
 			return fmt_hal_result(resp, resp_size, ret);
 		}
-		return rss_ctrl_resp_error(resp, resp_size, "need channel and value");
+		return rss_ctrl_resp_error(resp, resp_size, "need channel and positive value");
 	}
 
 	if (strcmp(cmd, "set-gop") == 0) {
@@ -330,14 +334,16 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 	if (strcmp(cmd, "get-bitrate") == 0) {
 		if (rss_json_get_int(cmd_json, "channel", &chn) == 0 && chn >= 0 &&
 		    chn < st->stream_count) {
+			uint32_t target = st->streams[chn].enc_cfg.bitrate;
 			uint32_t avg = 0;
-			if (!st->v4l2_backend)
+			if (st->v4l2_backend)
+				rvd_v4l2_h264_get_bitrate(st->v4l2, &target, &avg);
+			else
 				RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx,
 					     st->streams[chn].chn, &avg);
 			cJSON *r = cJSON_CreateObject();
 			cJSON_AddStringToObject(r, "status", "ok");
-			cJSON_AddNumberToObject(r, "bitrate",
-						(double)st->streams[chn].enc_cfg.bitrate);
+			cJSON_AddNumberToObject(r, "bitrate", (double)target);
 			cJSON_AddNumberToObject(r, "avg_bitrate", (double)avg);
 			return rss_ctrl_resp_json(resp, resp_size, r);
 		}
@@ -2344,7 +2350,9 @@ static int handle_config_cmd(const char *cmd, const char *cmd_json, rvd_state_t 
 		for (int i = 0; i < st->stream_count; i++) {
 			rvd_stream_t *s = &st->streams[i];
 			uint32_t avg_br = 0;
-			if (!st->v4l2_backend)
+			if (st->v4l2_backend)
+				rvd_v4l2_h264_get_bitrate(st->v4l2, NULL, &avg_br);
+			else
 				RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx, s->chn,
 					     &avg_br);
 			cJSON *item = cJSON_CreateObject();
@@ -2410,7 +2418,9 @@ static int handle_config_cmd(const char *cmd, const char *cmd_json, rvd_state_t 
 		cJSON *arr = cJSON_AddArrayToObject(r, "streams");
 		for (int i = 0; i < st->stream_count; i++) {
 			uint32_t avg_br = 0;
-			if (!st->v4l2_backend)
+			if (st->v4l2_backend)
+				rvd_v4l2_h264_get_bitrate(st->v4l2, NULL, &avg_br);
+			else
 				RSS_HAL_CALL(st->ops, enc_get_avg_bitrate, st->hal_ctx,
 					     st->streams[i].chn, &avg_br);
 			cJSON *item = cJSON_CreateObject();
@@ -2453,7 +2463,11 @@ int rvd_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 	/* The standalone backend initializes the ISP HAL for sensor bring-up and
 	 * tuning, but it has no IMP framesource or encoder graph. Keep its control
 	 * surface explicit so only controls backed by initialized state get through. */
+	if (st->v4l2_backend &&
+	    (len = handle_isp_cmd(cmd, cmd_json, st, resp_buf, resp_buf_size)) > 0)
+		return len;
 	if (st->v4l2_backend && strcmp(cmd, "request-idr") != 0 &&
+	    strcmp(cmd, "set-bitrate") != 0 &&
 	    strcmp(cmd, "get-bitrate") != 0 && strcmp(cmd, "get-fps") != 0 &&
 	    strcmp(cmd, "get-gop") != 0 && strcmp(cmd, "get-qp-bounds") != 0 &&
 	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "get-sensor-fps") != 0 &&

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -268,9 +268,13 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 	if (strcmp(cmd, "set-gop") == 0) {
 		if (rss_json_get_int(cmd_json, "channel", &chn) == 0 &&
 		    rss_json_get_int(cmd_json, "value", &val) == 0 && chn >= 0 &&
-		    chn < st->stream_count) {
-			int ret = RSS_HAL_CALL(st->ops, enc_set_gop, st->hal_ctx,
-					       st->streams[chn].chn, val);
+		    chn < st->stream_count && val > 0) {
+			int ret;
+			if (st->v4l2_backend)
+				ret = rvd_v4l2_h264_set_gop(st->v4l2, (uint32_t)val);
+			else
+				ret = RSS_HAL_CALL(st->ops, enc_set_gop, st->hal_ctx,
+						   st->streams[chn].chn, val);
 			const char *key = rvd_persist_key(&st->streams[chn], "gop");
 			if (ret == 0) {
 				st->streams[chn].enc_cfg.gop_length = val;
@@ -280,7 +284,7 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 			}
 			return fmt_hal_result(resp, resp_size, ret);
 		}
-		return rss_ctrl_resp_error(resp, resp_size, "need channel and value");
+		return rss_ctrl_resp_error(resp, resp_size, "need channel and positive value");
 	}
 
 	if (strcmp(cmd, "set-fps") == 0) {
@@ -424,7 +428,9 @@ static int handle_encoder_cmd(const char *cmd, const char *cmd_json, rvd_state_t
 		if (rss_json_get_int(cmd_json, "channel", &chn) == 0 && chn >= 0 &&
 		    chn < st->stream_count) {
 			uint32_t gop = st->streams[chn].enc_cfg.gop_length;
-			if (!st->v4l2_backend)
+			if (st->v4l2_backend)
+				rvd_v4l2_h264_get_gop(st->v4l2, &gop);
+			else
 				RSS_HAL_CALL(st->ops, enc_get_gop_attr, st->hal_ctx,
 					     st->streams[chn].chn, &gop);
 			cJSON *r = cJSON_CreateObject();
@@ -2468,7 +2474,8 @@ int rvd_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 		return len;
 	if (st->v4l2_backend && strcmp(cmd, "request-idr") != 0 &&
 	    strcmp(cmd, "set-bitrate") != 0 && strcmp(cmd, "get-bitrate") != 0 &&
-	    strcmp(cmd, "get-fps") != 0 && strcmp(cmd, "get-gop") != 0 &&
+	    strcmp(cmd, "set-gop") != 0 && strcmp(cmd, "get-fps") != 0 &&
+	    strcmp(cmd, "get-gop") != 0 &&
 	    strcmp(cmd, "get-qp-bounds") != 0 && strcmp(cmd, "get-rc-mode") != 0 &&
 	    strcmp(cmd, "get-sensor-fps") != 0 && strcmp(cmd, "config-show") != 0 &&
 	    strcmp(cmd, "status") != 0)

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -2475,10 +2475,9 @@ int rvd_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 	if (st->v4l2_backend && strcmp(cmd, "request-idr") != 0 &&
 	    strcmp(cmd, "set-bitrate") != 0 && strcmp(cmd, "get-bitrate") != 0 &&
 	    strcmp(cmd, "set-gop") != 0 && strcmp(cmd, "get-fps") != 0 &&
-	    strcmp(cmd, "get-gop") != 0 &&
-	    strcmp(cmd, "get-qp-bounds") != 0 && strcmp(cmd, "get-rc-mode") != 0 &&
-	    strcmp(cmd, "get-sensor-fps") != 0 && strcmp(cmd, "config-show") != 0 &&
-	    strcmp(cmd, "status") != 0)
+	    strcmp(cmd, "get-gop") != 0 && strcmp(cmd, "get-qp-bounds") != 0 &&
+	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "get-sensor-fps") != 0 &&
+	    strcmp(cmd, "config-show") != 0 && strcmp(cmd, "status") != 0)
 		return rss_ctrl_resp_error(resp_buf, resp_buf_size,
 					   "not supported by the V4L2 backend");
 

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -2450,14 +2450,14 @@ int rvd_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 	if (rss_json_get_str(cmd_json, "cmd", cmd, sizeof(cmd)) != 0)
 		return rss_ctrl_resp_error(resp_buf, resp_buf_size, "missing cmd");
 
-	/* The standalone backend has no initialized IMP HAL graph. Keep its small
-	 * control surface explicit so a web/API request cannot fall through to an
-	 * operation on uninitialized SDK state. */
+	/* The standalone backend initializes the ISP HAL for sensor bring-up and
+	 * tuning, but it has no IMP framesource or encoder graph. Keep its control
+	 * surface explicit so only controls backed by initialized state get through. */
 	if (st->v4l2_backend && strcmp(cmd, "request-idr") != 0 &&
 	    strcmp(cmd, "get-bitrate") != 0 && strcmp(cmd, "get-fps") != 0 &&
 	    strcmp(cmd, "get-gop") != 0 && strcmp(cmd, "get-qp-bounds") != 0 &&
-	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "config-show") != 0 &&
-	    strcmp(cmd, "status") != 0)
+	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "get-sensor-fps") != 0 &&
+	    strcmp(cmd, "config-show") != 0 && strcmp(cmd, "status") != 0)
 		return rss_ctrl_resp_error(resp_buf, resp_buf_size,
 					   "not supported by the V4L2 backend");
 

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -2467,11 +2467,11 @@ int rvd_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 	    (len = handle_isp_cmd(cmd, cmd_json, st, resp_buf, resp_buf_size)) > 0)
 		return len;
 	if (st->v4l2_backend && strcmp(cmd, "request-idr") != 0 &&
-	    strcmp(cmd, "set-bitrate") != 0 &&
-	    strcmp(cmd, "get-bitrate") != 0 && strcmp(cmd, "get-fps") != 0 &&
-	    strcmp(cmd, "get-gop") != 0 && strcmp(cmd, "get-qp-bounds") != 0 &&
-	    strcmp(cmd, "get-rc-mode") != 0 && strcmp(cmd, "get-sensor-fps") != 0 &&
-	    strcmp(cmd, "config-show") != 0 && strcmp(cmd, "status") != 0)
+	    strcmp(cmd, "set-bitrate") != 0 && strcmp(cmd, "get-bitrate") != 0 &&
+	    strcmp(cmd, "get-fps") != 0 && strcmp(cmd, "get-gop") != 0 &&
+	    strcmp(cmd, "get-qp-bounds") != 0 && strcmp(cmd, "get-rc-mode") != 0 &&
+	    strcmp(cmd, "get-sensor-fps") != 0 && strcmp(cmd, "config-show") != 0 &&
+	    strcmp(cmd, "status") != 0)
 		return rss_ctrl_resp_error(resp_buf, resp_buf_size,
 					   "not supported by the V4L2 backend");
 

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -208,6 +208,7 @@ static const char *rc_mode_str(rss_rc_mode_t m)
 static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
 			       int default_w, int default_h, int default_fps, int default_br);
 static int read_sensor_proc_int(int idx, const char *key, int base, int def);
+static int find_active_sensor_proc_index(void);
 static void load_sensor_from_section(rss_config_t *cfg, const char *section,
 				     rss_sensor_config_t *sensor, int proc_idx);
 
@@ -219,6 +220,8 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	int sensor_w;
 	int sensor_h;
 	int sensor_fps;
+	int sensor_proc_idx;
+	bool sensor_fps_known;
 	int ret;
 
 	device = rss_config_get_str(st->cfg, "system", "video_device", "/dev/video0");
@@ -261,19 +264,21 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	}
 	st->hal_initialized = true;
 
-	sensor_w = read_sensor_proc_int(0, "width", 10, 0);
-	sensor_h = read_sensor_proc_int(0, "height", 10, 0);
+	sensor_proc_idx = find_active_sensor_proc_index();
+	sensor_w = read_sensor_proc_int(sensor_proc_idx, "width", 10, 0);
+	sensor_h = read_sensor_proc_int(sensor_proc_idx, "height", 10, 0);
 	if (sensor_w > 0 && sensor_h > 0) {
-		RSS_INFO("sensor resolution: %dx%d", sensor_w, sensor_h);
+		RSS_INFO("active sensor%d: %dx%d", sensor_proc_idx, sensor_w, sensor_h);
 	} else {
 		sensor_w = 1920;
 		sensor_h = 1080;
-		RSS_WARN("could not determine sensor resolution; using %dx%d",
+		RSS_WARN("could not determine active sensor resolution; using %dx%d",
 			 sensor_w, sensor_h);
 	}
-	sensor_fps = read_sensor_proc_int(0, "max_fps", 10, 0);
+	sensor_fps = read_sensor_proc_int(sensor_proc_idx, "max_fps", 10, 0);
 	if (sensor_fps <= 0)
-		sensor_fps = read_sensor_proc_int(0, "fps", 10, 0);
+		sensor_fps = read_sensor_proc_int(sensor_proc_idx, "fps", 10, 0);
+	sensor_fps_known = sensor_fps > 0;
 	if (sensor_fps <= 0)
 		sensor_fps = 25;
 
@@ -286,6 +291,33 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	if (stream->enc_cfg.codec != RSS_CODEC_H264) {
 		RSS_FATAL("V4L2 backend currently requires stream0 codec=h264");
 		return RSS_ERR_NOTSUP;
+	}
+
+	/*
+	 * The public V4L2 node emits every frame produced by the active sensor;
+	 * it has no IMP framesource decimator.  Keep encoder rate control, GOP
+	 * defaults, ring metadata and downstream RTP on that measured clock.
+	 * Reprogramming the physical sensor here is unsafe: some sensor drivers
+	 * advertise the generic FPS control but cannot switch modes while the
+	 * ISP pipeline is active.
+	 */
+	if (sensor_fps_known &&
+	    (stream->enc_cfg.fps_num != (uint32_t)sensor_fps ||
+	     stream->enc_cfg.fps_den != 1)) {
+		RSS_WARN("V4L2 stream0 rate %u/%u overridden by active sensor%d rate %d/1",
+			 stream->enc_cfg.fps_num, stream->enc_cfg.fps_den, sensor_proc_idx,
+			 sensor_fps);
+		stream->fs_cfg.fps_num = (uint32_t)sensor_fps;
+		stream->fs_cfg.fps_den = 1;
+		stream->enc_cfg.fps_num = (uint32_t)sensor_fps;
+		stream->enc_cfg.fps_den = 1;
+		if (!rss_config_get_str(st->cfg, "stream0", "gop", NULL))
+			stream->enc_cfg.gop_length = (uint32_t)sensor_fps;
+	}
+	if (sensor_fps_known) {
+		st->sensor_base_fps_num = (uint32_t)sensor_fps;
+		st->sensor_base_fps_den = 1;
+		RSS_INFO("sensor%d fps: %d/1", sensor_proc_idx, sensor_fps);
 	}
 	if (rss_config_get_bool(st->cfg, "stream1", "enabled", true) ||
 	    rss_config_get_bool(st->cfg, "jpeg", "enabled", true) ||
@@ -361,6 +393,31 @@ static int read_sensor_proc_int(int idx, const char *key, int base, int def)
 	char path[64];
 	sensor_proc_path(path, sizeof(path), idx, key);
 	return read_procfs_int(path, base, def);
+}
+
+static int find_active_sensor_proc_index(void)
+{
+	for (int idx = 0; idx < RVD_MAX_SENSORS; idx++) {
+		char path[64];
+		char *status;
+		char *end;
+
+		sensor_proc_path(path, sizeof(path), idx, "status");
+		status = rss_read_file(path, NULL);
+		if (!status)
+			continue;
+		end = status + strlen(status);
+		while (end > status && (end[-1] == '\n' || end[-1] == '\r' || end[-1] == ' ' ||
+					end[-1] == '\t'))
+			*--end = '\0';
+		if (strcmp(status, "active") == 0) {
+			free(status);
+			return idx;
+		}
+		free(status);
+	}
+
+	return 0;
 }
 
 /* Load sensor config from an INI section, with a per-index procfs

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -272,8 +272,8 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	} else {
 		sensor_w = 1920;
 		sensor_h = 1080;
-		RSS_WARN("could not determine active sensor resolution; using %dx%d",
-			 sensor_w, sensor_h);
+		RSS_WARN("could not determine active sensor resolution; using %dx%d", sensor_w,
+			 sensor_h);
 	}
 	sensor_fps = read_sensor_proc_int(sensor_proc_idx, "max_fps", 10, 0);
 	if (sensor_fps <= 0)
@@ -282,8 +282,7 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	if (sensor_fps <= 0)
 		sensor_fps = 25;
 
-	load_stream_config(st->cfg, "stream0", stream, sensor_w, sensor_h, sensor_fps,
-			   8000000);
+	load_stream_config(st->cfg, "stream0", stream, sensor_w, sensor_h, sensor_fps, 8000000);
 	stream->fs_chn = 0;
 	stream->chn = 0;
 	stream->sensor_idx = 0;
@@ -302,8 +301,7 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	 * ISP pipeline is active.
 	 */
 	if (sensor_fps_known &&
-	    (stream->enc_cfg.fps_num != (uint32_t)sensor_fps ||
-	     stream->enc_cfg.fps_den != 1)) {
+	    (stream->enc_cfg.fps_num != (uint32_t)sensor_fps || stream->enc_cfg.fps_den != 1)) {
 		RSS_WARN("V4L2 stream0 rate %u/%u overridden by active sensor%d rate %d/1",
 			 stream->enc_cfg.fps_num, stream->enc_cfg.fps_den, sensor_proc_idx,
 			 sensor_fps);
@@ -407,8 +405,8 @@ static int find_active_sensor_proc_index(void)
 		if (!status)
 			continue;
 		end = status + strlen(status);
-		while (end > status && (end[-1] == '\n' || end[-1] == '\r' || end[-1] == ' ' ||
-					end[-1] == '\t'))
+		while (end > status &&
+		       (end[-1] == '\n' || end[-1] == '\r' || end[-1] == ' ' || end[-1] == '\t'))
 			*--end = '\0';
 		if (strcmp(status, "active") == 0) {
 			free(status);

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -208,9 +208,12 @@ static const char *rc_mode_str(rss_rc_mode_t m)
 static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
 			       int default_w, int default_h, int default_fps, int default_br);
 static int read_sensor_proc_int(int idx, const char *key, int base, int def);
+static void load_sensor_from_section(rss_config_t *cfg, const char *section,
+				     rss_sensor_config_t *sensor, int proc_idx);
 
 static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 {
+	rss_multi_sensor_config_t multi_cfg = {0};
 	rvd_stream_t *stream = &st->streams[0];
 	const char *device;
 	int sensor_w;
@@ -230,6 +233,33 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	st->use_isp_osd = false;
 	st->ivs_enabled = false;
 	atomic_store(&st->ivs_active, false);
+
+	/* V4L2 exposes frames from the TX-ISP pipeline, but opening /dev/video0
+	 * does not bind or start the sensor. Bring up ISP + sensor through the
+	 * same HAL sequence as the regular IMP pipeline before configuring the
+	 * capture and encoder backends. */
+	load_sensor_from_section(st->cfg, "sensor", &multi_cfg.sensors[0], 0);
+	multi_cfg.sensor_count = 1;
+	if (!multi_cfg.sensors[0].name[0]) {
+		RSS_FATAL("sensor name not in config and not in /proc/jz/sensor/sensor0/name");
+		return RSS_ERR;
+	}
+	if (multi_cfg.sensors[0].i2c_addr == 0) {
+		RSS_FATAL("i2c_addr not in config and not in /proc/jz/sensor/sensor0/i2c_addr");
+		return RSS_ERR;
+	}
+	RSS_DEBUG("sensor0: %s i2c=0x%02x bus=%d id=%d mclk=%d vin=%d boot=%d",
+		  multi_cfg.sensors[0].name, multi_cfg.sensors[0].i2c_addr,
+		  multi_cfg.sensors[0].i2c_adapter, multi_cfg.sensors[0].sensor_id,
+		  multi_cfg.sensors[0].mclk, multi_cfg.sensors[0].vin_type,
+		  multi_cfg.sensors[0].default_boot);
+
+	ret = RSS_HAL_CALL(st->ops, init, st->hal_ctx, &multi_cfg);
+	if (ret != RSS_OK) {
+		RSS_FATAL("HAL init failed: %d", ret);
+		return ret;
+	}
+	st->hal_initialized = true;
 
 	sensor_w = read_sensor_proc_int(0, "width", 10, 0);
 	sensor_h = read_sensor_proc_int(0, "height", 10, 0);

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -212,6 +212,61 @@ static int find_active_sensor_proc_index(void);
 static void load_sensor_from_section(rss_config_t *cfg, const char *section,
 				     rss_sensor_config_t *sensor, int proc_idx);
 
+static void apply_primary_isp_tuning(rvd_state_t *st, rss_config_t *cfg, bool multi)
+{
+	const char *img = "image";
+	int brightness = rss_config_get_int(cfg, img, "brightness", 128);
+	int contrast = rss_config_get_int(cfg, img, "contrast", 128);
+	int saturation = rss_config_get_int(cfg, img, "saturation", 128);
+	int sharpness = rss_config_get_int(cfg, img, "sharpness", 128);
+	int sinter = rss_config_get_int(cfg, img, "sinter", 128);
+	int temper = rss_config_get_int(cfg, img, "temper", 128);
+	int hue = rss_config_get_int(cfg, img, "hue", 128);
+	int ae_comp = rss_config_get_int(cfg, img, "ae_comp", 128);
+	int max_again = rss_config_get_int(cfg, img, "max_again", 160);
+	int max_dgain = rss_config_get_int(cfg, img, "max_dgain", 80);
+	int dpc = rss_config_get_int(cfg, img, "dpc_strength", 128);
+	int drc = rss_config_get_int(cfg, img, "drc_strength", 128);
+	int highlight = rss_config_get_int(cfg, img, "highlight_depress", 0);
+	int backlight = rss_config_get_int(cfg, img, "backlight_comp", 0);
+	uint8_t defog = (uint8_t)rss_config_get_int(cfg, img, "defog_strength", 128);
+	int hflip = rss_config_get_int(cfg, img, "hflip", 0);
+	int vflip = rss_config_get_int(cfg, img, "vflip", 0);
+	int antiflicker =
+		rss_config_get_int(cfg, multi ? "sensor0" : "sensor", "antiflicker", 2);
+	int bypass_ret;
+
+	RSS_HAL_CALL(st->ops, isp_set_brightness, st->hal_ctx, brightness);
+	RSS_HAL_CALL(st->ops, isp_set_contrast, st->hal_ctx, contrast);
+	RSS_HAL_CALL(st->ops, isp_set_saturation, st->hal_ctx, saturation);
+	RSS_HAL_CALL(st->ops, isp_set_sharpness, st->hal_ctx, sharpness);
+	RSS_HAL_CALL(st->ops, isp_set_sinter_strength, st->hal_ctx, sinter);
+	RSS_HAL_CALL(st->ops, isp_set_temper_strength, st->hal_ctx, temper);
+	RSS_HAL_CALL(st->ops, isp_set_hue, st->hal_ctx, hue);
+	RSS_HAL_CALL(st->ops, isp_set_ae_comp, st->hal_ctx, ae_comp);
+	RSS_HAL_CALL(st->ops, isp_set_max_again, st->hal_ctx, max_again);
+	RSS_HAL_CALL(st->ops, isp_set_max_dgain, st->hal_ctx, max_dgain);
+	RSS_HAL_CALL(st->ops, isp_set_dpc_strength, st->hal_ctx, dpc);
+	RSS_HAL_CALL(st->ops, isp_set_drc_strength, st->hal_ctx, drc);
+	RSS_HAL_CALL(st->ops, isp_set_highlight_depress, st->hal_ctx, highlight);
+	RSS_HAL_CALL(st->ops, isp_set_backlight_comp, st->hal_ctx, backlight);
+	RSS_HAL_CALL(st->ops, isp_set_defog_strength_adv, st->hal_ctx, &defog);
+	RSS_HAL_CALL(st->ops, isp_set_running_mode, st->hal_ctx, RSS_ISP_DAY);
+	bypass_ret = RSS_HAL_CALL(st->ops, isp_set_bypass, st->hal_ctx, 1);
+	RSS_HAL_CALL(st->ops, isp_set_antiflicker, st->hal_ctx, antiflicker);
+	RSS_HAL_CALL(st->ops, isp_set_hflip, st->hal_ctx, hflip);
+	RSS_HAL_CALL(st->ops, isp_set_vflip, st->hal_ctx, vflip);
+
+	RSS_DEBUG("isp tuning: brightness=%d contrast=%d saturation=%d sharpness=%d",
+		  brightness, contrast, saturation, sharpness);
+	RSS_DEBUG("  sinter=%d temper=%d hue=%d ae_comp=%d", sinter, temper, hue, ae_comp);
+	RSS_DEBUG("  max_again=%d max_dgain=%d dpc=%d drc=%d", max_again, max_dgain, dpc,
+		  drc);
+	RSS_DEBUG("  highlight=%d backlight=%d defog=%d", highlight, backlight, defog);
+	RSS_DEBUG("  hflip=%d vflip=%d antiflicker=%d bypass=%d", hflip, vflip, antiflicker,
+		  bypass_ret == RSS_OK);
+}
+
 static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 {
 	rss_multi_sensor_config_t multi_cfg = {0};
@@ -263,6 +318,7 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 		return ret;
 	}
 	st->hal_initialized = true;
+	apply_primary_isp_tuning(st, st->cfg, false);
 
 	sensor_proc_idx = find_active_sensor_proc_index();
 	sensor_w = read_sensor_proc_int(sensor_proc_idx, "width", 10, 0);
@@ -800,59 +856,7 @@ int rvd_pipeline_init(rvd_state_t *st)
 	}
 
 	/* ── 3c. ISP tuning defaults (apply to all sensors) ── */
-	{
-		const char *img = "image";
-		int brightness = rss_config_get_int(cfg, img, "brightness", 128);
-		int contrast = rss_config_get_int(cfg, img, "contrast", 128);
-		int saturation = rss_config_get_int(cfg, img, "saturation", 128);
-		int sharpness = rss_config_get_int(cfg, img, "sharpness", 128);
-		int sinter = rss_config_get_int(cfg, img, "sinter", 128);
-		int temper = rss_config_get_int(cfg, img, "temper", 128);
-		int hue = rss_config_get_int(cfg, img, "hue", 128);
-		int ae_comp = rss_config_get_int(cfg, img, "ae_comp", 128);
-		int max_again = rss_config_get_int(cfg, img, "max_again", 160);
-		int max_dgain = rss_config_get_int(cfg, img, "max_dgain", 80);
-		int dpc = rss_config_get_int(cfg, img, "dpc_strength", 128);
-		int drc = rss_config_get_int(cfg, img, "drc_strength", 128);
-		int highlight = rss_config_get_int(cfg, img, "highlight_depress", 0);
-		int backlight = rss_config_get_int(cfg, img, "backlight_comp", 0);
-		uint8_t defog = (uint8_t)rss_config_get_int(cfg, img, "defog_strength", 128);
-		int hflip = rss_config_get_int(cfg, img, "hflip", 0);
-		int vflip = rss_config_get_int(cfg, img, "vflip", 0);
-		int antiflicker =
-			rss_config_get_int(cfg, multi ? "sensor0" : "sensor", "antiflicker", 2);
-
-		RSS_HAL_CALL(st->ops, isp_set_brightness, st->hal_ctx, brightness);
-		RSS_HAL_CALL(st->ops, isp_set_contrast, st->hal_ctx, contrast);
-		RSS_HAL_CALL(st->ops, isp_set_saturation, st->hal_ctx, saturation);
-		RSS_HAL_CALL(st->ops, isp_set_sharpness, st->hal_ctx, sharpness);
-		RSS_HAL_CALL(st->ops, isp_set_sinter_strength, st->hal_ctx, sinter);
-		RSS_HAL_CALL(st->ops, isp_set_temper_strength, st->hal_ctx, temper);
-		RSS_HAL_CALL(st->ops, isp_set_hue, st->hal_ctx, hue);
-		RSS_HAL_CALL(st->ops, isp_set_ae_comp, st->hal_ctx, ae_comp);
-		RSS_HAL_CALL(st->ops, isp_set_max_again, st->hal_ctx, max_again);
-		RSS_HAL_CALL(st->ops, isp_set_max_dgain, st->hal_ctx, max_dgain);
-		RSS_HAL_CALL(st->ops, isp_set_dpc_strength, st->hal_ctx, dpc);
-		RSS_HAL_CALL(st->ops, isp_set_drc_strength, st->hal_ctx, drc);
-		RSS_HAL_CALL(st->ops, isp_set_highlight_depress, st->hal_ctx, highlight);
-		RSS_HAL_CALL(st->ops, isp_set_backlight_comp, st->hal_ctx, backlight);
-		RSS_HAL_CALL(st->ops, isp_set_defog_strength_adv, st->hal_ctx, &defog);
-		RSS_HAL_CALL(st->ops, isp_set_running_mode, st->hal_ctx, RSS_ISP_DAY);
-		ret = RSS_HAL_CALL(st->ops, isp_set_bypass, st->hal_ctx, 1);
-		RSS_HAL_CALL(st->ops, isp_set_antiflicker, st->hal_ctx, antiflicker);
-		RSS_HAL_CALL(st->ops, isp_set_hflip, st->hal_ctx, hflip);
-		RSS_HAL_CALL(st->ops, isp_set_vflip, st->hal_ctx, vflip);
-
-		RSS_DEBUG("isp tuning: brightness=%d contrast=%d saturation=%d "
-			  "sharpness=%d",
-			  brightness, contrast, saturation, sharpness);
-		RSS_DEBUG("  sinter=%d temper=%d hue=%d ae_comp=%d", sinter, temper, hue, ae_comp);
-		RSS_DEBUG("  max_again=%d max_dgain=%d dpc=%d drc=%d", max_again, max_dgain, dpc,
-			  drc);
-		RSS_DEBUG("  highlight=%d backlight=%d defog=%d", highlight, backlight, defog);
-		RSS_DEBUG("  hflip=%d vflip=%d antiflicker=%d bypass=%d", hflip, vflip, antiflicker,
-			  ret == RSS_OK);
-	}
+	apply_primary_isp_tuning(st, cfg, multi);
 
 	/* Dual-sensor: read sensor attrs + disable AeFreeze + set CustomMode (prudynt pattern).
 	 * GetSensorAttr may trigger ISP to initialize the sensor pipeline. */

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -207,11 +207,15 @@ static const char *rc_mode_str(rss_rc_mode_t m)
 
 static void load_stream_config(rss_config_t *cfg, const char *section, rvd_stream_t *s,
 			       int default_w, int default_h, int default_fps, int default_br);
+static int read_sensor_proc_int(int idx, const char *key, int base, int def);
 
 static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 {
 	rvd_stream_t *stream = &st->streams[0];
 	const char *device;
+	int sensor_w;
+	int sensor_h;
+	int sensor_fps;
 	int ret;
 
 	device = rss_config_get_str(st->cfg, "system", "video_device", "/dev/video0");
@@ -227,7 +231,24 @@ static int rvd_pipeline_init_v4l2(rvd_state_t *st)
 	st->ivs_enabled = false;
 	atomic_store(&st->ivs_active, false);
 
-	load_stream_config(st->cfg, "stream0", stream, 2560, 1440, 25, 8000000);
+	sensor_w = read_sensor_proc_int(0, "width", 10, 0);
+	sensor_h = read_sensor_proc_int(0, "height", 10, 0);
+	if (sensor_w > 0 && sensor_h > 0) {
+		RSS_INFO("sensor resolution: %dx%d", sensor_w, sensor_h);
+	} else {
+		sensor_w = 1920;
+		sensor_h = 1080;
+		RSS_WARN("could not determine sensor resolution; using %dx%d",
+			 sensor_w, sensor_h);
+	}
+	sensor_fps = read_sensor_proc_int(0, "max_fps", 10, 0);
+	if (sensor_fps <= 0)
+		sensor_fps = read_sensor_proc_int(0, "fps", 10, 0);
+	if (sensor_fps <= 0)
+		sensor_fps = 25;
+
+	load_stream_config(st->cfg, "stream0", stream, sensor_w, sensor_h, sensor_fps,
+			   8000000);
 	stream->fs_chn = 0;
 	stream->chn = 0;
 	stream->sensor_idx = 0;

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -232,8 +232,7 @@ static void apply_primary_isp_tuning(rvd_state_t *st, rss_config_t *cfg, bool mu
 	uint8_t defog = (uint8_t)rss_config_get_int(cfg, img, "defog_strength", 128);
 	int hflip = rss_config_get_int(cfg, img, "hflip", 0);
 	int vflip = rss_config_get_int(cfg, img, "vflip", 0);
-	int antiflicker =
-		rss_config_get_int(cfg, multi ? "sensor0" : "sensor", "antiflicker", 2);
+	int antiflicker = rss_config_get_int(cfg, multi ? "sensor0" : "sensor", "antiflicker", 2);
 	int bypass_ret;
 
 	RSS_HAL_CALL(st->ops, isp_set_brightness, st->hal_ctx, brightness);
@@ -257,11 +256,10 @@ static void apply_primary_isp_tuning(rvd_state_t *st, rss_config_t *cfg, bool mu
 	RSS_HAL_CALL(st->ops, isp_set_hflip, st->hal_ctx, hflip);
 	RSS_HAL_CALL(st->ops, isp_set_vflip, st->hal_ctx, vflip);
 
-	RSS_DEBUG("isp tuning: brightness=%d contrast=%d saturation=%d sharpness=%d",
-		  brightness, contrast, saturation, sharpness);
+	RSS_DEBUG("isp tuning: brightness=%d contrast=%d saturation=%d sharpness=%d", brightness,
+		  contrast, saturation, sharpness);
 	RSS_DEBUG("  sinter=%d temper=%d hue=%d ae_comp=%d", sinter, temper, hue, ae_comp);
-	RSS_DEBUG("  max_again=%d max_dgain=%d dpc=%d drc=%d", max_again, max_dgain, dpc,
-		  drc);
+	RSS_DEBUG("  max_again=%d max_dgain=%d dpc=%d drc=%d", max_again, max_dgain, dpc, drc);
 	RSS_DEBUG("  highlight=%d backlight=%d defog=%d", highlight, backlight, defog);
 	RSS_DEBUG("  hflip=%d vflip=%d antiflicker=%d bypass=%d", hflip, vflip, antiflicker,
 		  bypass_ret == RSS_OK);

--- a/tests/test_ctrl.c
+++ b/tests/test_ctrl.c
@@ -726,6 +726,17 @@ TEST get_sensor_fps_is_available_on_v4l2(void)
 	PASS();
 }
 
+TEST isp_tuning_is_available_on_v4l2(void)
+{
+	setup();
+	st.v4l2_backend = true;
+	call("{\"cmd\":\"set-brightness\",\"value\":144}");
+	ASSERT(strstr(resp, "\"status\":\"ok\"") != NULL);
+	ASSERT_EQ(144, rec.set_brightness);
+	teardown();
+	PASS();
+}
+
 TEST set_qp_bounds_atomic_update(void)
 {
 	setup();
@@ -1241,6 +1252,7 @@ SUITE(ctrl_suite)
 	RUN_TEST(set_fps_clears_active_override);
 	RUN_TEST(get_sensor_fps_reports_live_and_base);
 	RUN_TEST(get_sensor_fps_is_available_on_v4l2);
+	RUN_TEST(isp_tuning_is_available_on_v4l2);
 	RUN_TEST(set_qp_bounds_atomic_update);
 	RUN_TEST(set_qp_bounds_neither_updated_on_failure);
 	RUN_TEST(set_rc_mode_stores_enum_not_string);

--- a/tests/test_ctrl.c
+++ b/tests/test_ctrl.c
@@ -711,6 +711,21 @@ TEST get_sensor_fps_reports_live_and_base(void)
 	PASS();
 }
 
+/* V4L2 still owns an initialized ISP HAL for sensor tuning.  Its control
+ * guard must permit readback without admitting IMP encoder controls. */
+TEST get_sensor_fps_is_available_on_v4l2(void)
+{
+	sensor_fps_setup();
+	st.v4l2_backend = true;
+	setenv("RSS_MOCK_SENSOR_FPS_ACTUAL", "25", 1);
+	call("{\"cmd\":\"get-sensor-fps\"}");
+	unsetenv("RSS_MOCK_SENSOR_FPS_ACTUAL");
+	ASSERT(strstr(resp, "\"status\":\"ok\"") != NULL);
+	ASSERT(strstr(resp, "\"fps_num\":25") != NULL);
+	teardown();
+	PASS();
+}
+
 TEST set_qp_bounds_atomic_update(void)
 {
 	setup();
@@ -1225,6 +1240,7 @@ SUITE(ctrl_suite)
 	RUN_TEST(sensor_fps_sensor_reject_aborts_everything);
 	RUN_TEST(set_fps_clears_active_override);
 	RUN_TEST(get_sensor_fps_reports_live_and_base);
+	RUN_TEST(get_sensor_fps_is_available_on_v4l2);
 	RUN_TEST(set_qp_bounds_atomic_update);
 	RUN_TEST(set_qp_bounds_neither_updated_on_failure);
 	RUN_TEST(set_rc_mode_stores_enum_not_string);


### PR DESCRIPTION
## Stack order

This PR is stacked after #33. The preceding commits are the V4L2 sensor-startup dependency; the runtime-control commits are the review delta.

## Change

The V4L2 path now uses the same existing `[image]` defaults as the IMP path, including max digital gain, AE compensation, and antiflicker. Live ISP controls are routed to the already initialized HAL.

The optional V4L2/OpenIMP encoder adapter also gains:

- deferred runtime bitrate changes;
- measured bitrate telemetry;
- deferred runtime GOP changes;
- GOP readback.

Bitrate and GOP changes are applied by the encoder thread between completed V4L2/OpenIMP ownership cycles, so control requests cannot race Submit/Dequeue/Release on the single T31 AVPU path. No device-specific profile or new configuration option is introduced.

## Dependencies

- #33
- gtxaspec/raptor-hal#8
- opensensor/openimp main `e236efffed2b2399e9d04dc159ece14a345b6e69`

## Validation

- 303/303 Raptor unit tests pass on the feature branch.
- Combined T31 integration branch: 316/316 tests, 14,541 assertions.
- T31 RVD cross-build with `V4L2_OPENIMP=1`.
- GitHub changed-line formatting check passes.
