### PR TITLE
fix(rsd): contain TCP backpressure recovery

### DIFF
--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -239,8 +239,8 @@ video_device = /dev/video0
 # session_name = Raptor Live  # SDP session name (s=)
 # session_info =              # SDP session description (i=)
 # session_timeout = 60        # RTSP session timeout in seconds (min 10)
-# tcp_sndbuf = 262144         # requested TCP send-buffer bytes; Linux doubles/caps it
-#                             # (lower saves memory/latency but must hold an IDR burst)
+# tcp_sndbuf = 65536          # requested TCP send-buffer bytes; Linux doubles/caps it
+#                             # (lower bounds stale data; blocking writes split large IDRs)
 # backchannel = false         # two-way audio (ONVIF Profile T). Offers PCMU,
 #                             # PCMA, opus, AAC and L16; the client picks by
 #                             # sending. TCP interleaved or UDP transport.

--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -239,7 +239,8 @@ video_device = /dev/video0
 # session_name = Raptor Live  # SDP session name (s=)
 # session_info =              # SDP session description (i=)
 # session_timeout = 60        # RTSP session timeout in seconds (min 10)
-# tcp_sndbuf = 65536          # TCP send buffer bytes (lower = less latency)
+# tcp_sndbuf = 262144         # requested TCP send-buffer bytes; Linux doubles/caps it
+#                             # (lower saves memory/latency but must hold an IDR burst)
 # backchannel = false         # two-way audio (ONVIF Profile T). Offers PCMU,
 #                             # PCMA, opus, AAC and L16; the client picks by
 #                             # sending. TCP interleaved or UDP transport.

--- a/rsd/rsd_idr_recovery.h
+++ b/rsd/rsd_idr_recovery.h
@@ -1,0 +1,40 @@
+/*
+ * rsd_idr_recovery.h -- suppress feedback between send stalls and IDR requests
+ */
+
+#ifndef RSD_IDR_RECOVERY_H
+#define RSD_IDR_RECOVERY_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define RSD_IDR_RECOVERY_MIN_INTERVAL_US 1000000
+
+typedef struct {
+	int64_t last_event_us;
+	bool has_event;
+} rsd_idr_recovery_t;
+
+static inline void rsd_idr_recovery_init(rsd_idr_recovery_t *state)
+{
+	state->last_event_us = 0;
+	state->has_event = false;
+}
+
+/* A produced keyframe and an explicit request are the same rate-limit event.
+ * Counting only requests lets an overflow immediately request another IDR
+ * while a natural keyframe is still blocked in the TCP writer. */
+static inline void rsd_idr_recovery_note(rsd_idr_recovery_t *state, int64_t now_us)
+{
+	if (!state->has_event || now_us > state->last_event_us)
+		state->last_event_us = now_us;
+	state->has_event = true;
+}
+
+static inline bool rsd_idr_recovery_request_due(const rsd_idr_recovery_t *state, int64_t now_us)
+{
+	return !state->has_event ||
+	       now_us - state->last_event_us > RSD_IDR_RECOVERY_MIN_INTERVAL_US;
+}
+
+#endif /* RSD_IDR_RECOVERY_H */

--- a/rsd/rsd_main.c
+++ b/rsd/rsd_main.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 	srv.session_timeout = rss_config_get_int(dctx.cfg, "rtsp", "session_timeout", 60);
 	if (srv.session_timeout < 10)
 		srv.session_timeout = 10;
-	srv.tcp_sndbuf = rss_config_get_int(dctx.cfg, "rtsp", "tcp_sndbuf", 64 * 1024);
+	srv.tcp_sndbuf = rss_config_get_int(dctx.cfg, "rtsp", "tcp_sndbuf", 256 * 1024);
 	srv.rtcp_sr = rss_config_get_bool(dctx.cfg, "rtsp", "rtcp_sr", true);
 	srv.idr_on_join = rss_config_get_bool(dctx.cfg, "rtsp", "idr_on_join", true);
 	srv.jpeg_enabled = rss_config_get_bool(dctx.cfg, "rtsp", "jpeg", false);

--- a/rsd/rsd_main.c
+++ b/rsd/rsd_main.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 	srv.session_timeout = rss_config_get_int(dctx.cfg, "rtsp", "session_timeout", 60);
 	if (srv.session_timeout < 10)
 		srv.session_timeout = 10;
-	srv.tcp_sndbuf = rss_config_get_int(dctx.cfg, "rtsp", "tcp_sndbuf", 256 * 1024);
+	srv.tcp_sndbuf = rss_config_get_int(dctx.cfg, "rtsp", "tcp_sndbuf", 64 * 1024);
 	srv.rtcp_sr = rss_config_get_bool(dctx.cfg, "rtsp", "rtcp_sr", true);
 	srv.idr_on_join = rss_config_get_bool(dctx.cfg, "rtsp", "idr_on_join", true);
 	srv.jpeg_enabled = rss_config_get_bool(dctx.cfg, "rtsp", "jpeg", false);

--- a/rsd/rsd_ring_reader.c
+++ b/rsd/rsd_ring_reader.c
@@ -14,6 +14,7 @@
 #include <pthread.h>
 
 #include "rsd.h"
+#include "rsd_idr_recovery.h"
 
 /* Forward declarations — called by send thread, defined below */
 static void rsd_send_audio_frame(rsd_client_t *c, uint32_t codec, const uint8_t *data, uint32_t len,
@@ -22,23 +23,17 @@ static void rsd_send_jpeg_frame(rsd_client_t *c, const uint8_t *data, uint32_t l
 				uint32_t rtp_ts);
 
 /*
- * Minimum interval between IDR requests from the reader's lag-recovery
- * paths (skip-to-latest, RSS_EOVERFLOW, sendq-full). Without this cap the
- * three call sites cascade on slow SoCs: each IDR is ~10x a P-frame, so
- * requesting one slows the reader, which triggers another skip, which
- * requests another IDR — observed as 1:9 IDR:SLICE on T20 (expected with
- * GOP=60 is 1:60). One second is enough: the encoder's own GOP will
- * produce its next IDR in due course, and the client already has the
- * current keyframe.
+ * Request one recovery IDR when the reader or a client falls behind. Natural
+ * keyframes count against the same guard: otherwise a large IDR blocked in a
+ * high-RTT TCP writer fills the sendq, whose overflow requests another large
+ * IDR, and the recovery path becomes a self-sustaining burst generator.
  */
-#define RSD_IDR_REQ_MIN_INTERVAL_US 1000000
-
-static inline void rsd_maybe_request_idr(rss_ring_t *ring, int64_t *last_req_us)
+static inline void rsd_maybe_request_idr(rss_ring_t *ring, rsd_idr_recovery_t *recovery)
 {
 	int64_t now_us = rss_timestamp_us();
-	if (now_us - *last_req_us > RSD_IDR_REQ_MIN_INTERVAL_US) {
+	if (rsd_idr_recovery_request_due(recovery, now_us)) {
 		rss_ring_request_idr(ring);
-		*last_req_us = now_us;
+		rsd_idr_recovery_note(recovery, now_us);
 	}
 }
 
@@ -302,7 +297,8 @@ void *rsd_video_reader_thread(void *arg)
 	int idle_count = 0;
 
 	/* Per-thread state for rsd_maybe_request_idr (see top of file). */
-	int64_t last_idr_req_us = 0;
+	rsd_idr_recovery_t idr_recovery;
+	rsd_idr_recovery_init(&idr_recovery);
 
 	uint64_t total_read = 0, total_pushed = 0, total_overflow = 0;
 	int64_t last_count_log = rss_timestamp_us();
@@ -574,7 +570,7 @@ void *rsd_video_reader_thread(void *arg)
 					 stream_idx, (unsigned long long)pre_seq,
 					 (unsigned long long)read_seq, (unsigned long long)skipped);
 				rctx->read_seq = read_seq;
-				rsd_maybe_request_idr(rctx->ring, &last_idr_req_us);
+				rsd_maybe_request_idr(rctx->ring, &idr_recovery);
 				break;
 			}
 			if (ret != 0)
@@ -583,6 +579,7 @@ void *rsd_video_reader_thread(void *arg)
 			rctx->read_seq = read_seq;
 			total_read++;
 
+			int64_t read_now_us = rss_timestamp_us();
 			if (video_ts_epoch == 0)
 				video_ts_epoch = meta.timestamp;
 			uint32_t rtp_ts = (uint32_t)((uint64_t)(meta.timestamp - video_ts_epoch) *
@@ -592,6 +589,9 @@ void *rsd_video_reader_thread(void *arg)
 				rtp_ts = last_rtp_ts + frame_dur;
 			last_rtp_ts = rtp_ts;
 			has_last_rtp_ts = true;
+
+			if (meta.is_key)
+				rsd_idr_recovery_note(&idr_recovery, read_now_us);
 
 			if (meta.is_key && rctx->last_codec != 2 && rctx->last_codec != 3 &&
 			    atomic_load_explicit(&rctx->sps_len, memory_order_relaxed) == 0)
@@ -656,7 +656,7 @@ void *rsd_video_reader_thread(void *arg)
 					total_pushed++;
 				else if (qret == RSD_SENDQ_DROPPED) {
 					c->waiting_keyframe = (c->video.jpeg == NULL);
-					rsd_maybe_request_idr(rctx->ring, &last_idr_req_us);
+					rsd_maybe_request_idr(rctx->ring, &idr_recovery);
 				}
 			}
 			pthread_mutex_unlock(&srv->clients_lock);

--- a/rsd/rsd_server.c
+++ b/rsd/rsd_server.c
@@ -199,15 +199,16 @@ static void accept_client(rsd_server_t *srv)
 		return;
 
 	/* Keep fd blocking for writes — non-blocking would drop RTP packets
-	 * when the send buffer fills (200KB keyframes need multiple writes).
+	 * when the send buffer fills (large keyframes need multiple writes).
 	 * Reads are handled by epoll with EPOLLIN. */
 	int one = 1;
 	setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
-	/* TCP send buffer: smaller = lower latency, but it must absorb one
-	 * access-unit burst plus ordinary ACK jitter. Linux doubles the requested
-	 * value and caps it at net.core.wmem_max; report the effective size so a
-	 * board whose ceiling is too low is diagnosable from one startup log. */
+	/* Bound the kernel backlog as well as the userspace sendq. A buffer large
+	 * enough for several access units only turns a slow link into stale video;
+	 * blocking writes already split large keyframes across ACK windows. Linux
+	 * doubles the requested value and caps it at net.core.wmem_max, so report
+	 * the effective size for board diagnostics. */
 	int sndbuf = srv->tcp_sndbuf;
 	if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) != 0) {
 		RSS_WARN("failed to set TCP send buffer to %d: %s", sndbuf, strerror(errno));

--- a/rsd/rsd_server.c
+++ b/rsd/rsd_server.c
@@ -199,15 +199,24 @@ static void accept_client(rsd_server_t *srv)
 		return;
 
 	/* Keep fd blocking for writes — non-blocking would drop RTP packets
-	 * when the send buffer fills (78KB keyframes need multiple writes).
+	 * when the send buffer fills (200KB keyframes need multiple writes).
 	 * Reads are handled by epoll with EPOLLIN. */
 	int one = 1;
 	setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
-	/* TCP send buffer: smaller = lower latency (less queuing), but must
-	 * fit at least one keyframe. 64KB is ~250ms at 2Mbps. */
+	/* TCP send buffer: smaller = lower latency, but it must absorb one
+	 * access-unit burst plus ordinary ACK jitter. Linux doubles the requested
+	 * value and caps it at net.core.wmem_max; report the effective size so a
+	 * board whose ceiling is too low is diagnosable from one startup log. */
 	int sndbuf = srv->tcp_sndbuf;
-	setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+	if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) != 0) {
+		RSS_WARN("failed to set TCP send buffer to %d: %s", sndbuf, strerror(errno));
+	} else {
+		int actual = 0;
+		socklen_t actual_len = sizeof(actual);
+		if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &actual, &actual_len) == 0)
+			RSS_DEBUG("TCP send buffer requested=%d actual=%d", sndbuf, actual);
+	}
 
 	rsd_client_t *client = calloc(1, sizeof(*client));
 	if (!client) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,8 +21,8 @@ CFLAGS = -Wall -Wextra -std=$(RAPTOR_STD) -D_GNU_SOURCE -g $(SAN_FLAGS) $(RAPTOR
 LDFLAGS = $(SAN_FLAGS) -lpthread -lrt -lm
 
 TEST_SRCS = main.c test_ric_json.c test_nal.c test_prebuf.c test_mux.c test_codec.c test_sdp.c test_ring.c test_rsp.c \
-            test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rad_clock.c test_resync.c \
-            test_backchannel.c test_config.c
+		    test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_idr_recovery.c test_rad_clock.c test_resync.c \
+		    test_backchannel.c test_config.c
 LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
            ../../raptor-common/src/rss_util.c ../../raptor-common/src/rss_log.c \
            ../../raptor-common/src/cJSON.c \

--- a/tests/main.c
+++ b/tests/main.c
@@ -20,6 +20,7 @@ extern SUITE(storage_suite);
 extern SUITE(timelapse_suite);
 extern SUITE(sendq_suite);
 extern SUITE(rad_clock_suite);
+extern SUITE(idr_recovery_suite);
 extern SUITE(resync_suite);
 extern SUITE(backchannel_suite);
 extern SUITE(config_suite);
@@ -49,6 +50,7 @@ int main(int argc, char **argv)
 	RUN_SUITE(timelapse_suite);
 	RUN_SUITE(sendq_suite);
 	RUN_SUITE(rad_clock_suite);
+	RUN_SUITE(idr_recovery_suite);
 	RUN_SUITE(resync_suite);
 	RUN_SUITE(backchannel_suite);
 	RUN_SUITE(config_suite);

--- a/tests/test_idr_recovery.c
+++ b/tests/test_idr_recovery.c
@@ -1,0 +1,59 @@
+/*
+ * test_idr_recovery.c -- keyframes and explicit requests share one guard
+ */
+
+#include "greatest.h"
+#include "../rsd/rsd_idr_recovery.h"
+
+TEST idr_recovery_allows_first_request(void)
+{
+	rsd_idr_recovery_t state;
+	rsd_idr_recovery_init(&state);
+
+	ASSERT(rsd_idr_recovery_request_due(&state, 100));
+	PASS();
+}
+
+TEST idr_recovery_request_starts_guard(void)
+{
+	rsd_idr_recovery_t state;
+	rsd_idr_recovery_init(&state);
+	rsd_idr_recovery_note(&state, 5000000);
+
+	ASSERT_FALSE(rsd_idr_recovery_request_due(&state, 5999999));
+	ASSERT_FALSE(rsd_idr_recovery_request_due(&state, 6000000));
+	ASSERT(rsd_idr_recovery_request_due(&state, 6000001));
+	PASS();
+}
+
+TEST idr_recovery_natural_keyframe_restarts_guard(void)
+{
+	rsd_idr_recovery_t state;
+	rsd_idr_recovery_init(&state);
+	rsd_idr_recovery_note(&state, 5000000); /* requested IDR */
+	rsd_idr_recovery_note(&state, 5800000); /* produced keyframe */
+
+	ASSERT_FALSE(rsd_idr_recovery_request_due(&state, 6500000));
+	ASSERT_FALSE(rsd_idr_recovery_request_due(&state, 6800000));
+	ASSERT(rsd_idr_recovery_request_due(&state, 6800001));
+	PASS();
+}
+
+TEST idr_recovery_ignores_older_event(void)
+{
+	rsd_idr_recovery_t state;
+	rsd_idr_recovery_init(&state);
+	rsd_idr_recovery_note(&state, 5000000);
+	rsd_idr_recovery_note(&state, 4000000);
+
+	ASSERT_EQ(5000000, state.last_event_us);
+	PASS();
+}
+
+SUITE(idr_recovery_suite)
+{
+	RUN_TEST(idr_recovery_allows_first_request);
+	RUN_TEST(idr_recovery_request_starts_guard);
+	RUN_TEST(idr_recovery_natural_keyframe_restarts_guard);
+	RUN_TEST(idr_recovery_ignores_older_event);
+}


### PR DESCRIPTION
## Summary

- raise the default requested RTSP/TCP send buffer from 64 KiB to 256 KiB and log the effective kernel value
- count naturally produced keyframes against the recovery-IDR throttle
- prevent a blocked IDR from causing queue overflow, another global IDR request, and a self-sustaining burst loop
- add focused tests for first request, request throttling, natural-keyframe throttling, and stale events

## Device evidence

Tested on a T31 OpenIMP/V4L2 camera at 1920x1080, 30 fps, and 4 Mbps with one standing LightNVR tunnel client plus one direct RTSP/TCP probe. Tunnel RTT ranged from 39.7 to 313.5 ms. Open-stack IDRs reached about 198 KiB, while the old 64 KiB request produced an effective 128 KiB socket buffer.

| Metric | Before | After |
| --- | ---: | ---: |
| Delivered FPS | 20.719 | 30.066 |
| Video payload | 3.062 Mbps | 4.010 Mbps |
| Maximum frame gap | 1532.278 ms | 35.489 ms |
| Gaps over 100 ms | 14 | 0 |
| RSD send-queue overflows | repeated | 0 |
| Keyframe cadence | 0.73-0.85 s, recovery amplified | 0.999 s |

The target kernel capped and doubled the new request to an effective 327,680-byte socket buffer. Both live views became synchronized after staging the binary.

At 8 Mbps the same high-jitter tunnel can still outrun the camera path; this change is deliberately bounded and does not grow the userspace queue or hide an undersized link behind additional latency.

## Validation

- TSan: 305 tests, 12,203 assertions
- ASan/UBSan: 305 tests, 12,203 assertions
- T31 Buildroot cross-build
- persistent on-device install followed by reboot and service-restart verification

The ASan/UBSan run retains the pre-existing unrelated signed-left-shift report in rmr_mux.c; the new recovery code has no sanitizer report.

## PR sequencing

This is intentionally separate from the V4L2 and WebRTC changes in #33-#36. Device validation used the integration build containing #32-#36. The branch is rebased to current upstream main for a clean one-commit diff. PR #32 touches nearby RSD reader code; if it lands first, preserve both its media-clock mapping and the natural-keyframe recovery note when resolving that small overlap.