### PR TITLE
ric: load IR-cut pulse timing from device metadata

### DIFF
--- a/ric/ric.h
+++ b/ric/ric.h
@@ -181,6 +181,7 @@ typedef struct {
 
 	/* Dual-GPIO IR-cut coil pulse width */
 	int pulse_ms;
+	bool pulse_ms_explicit; /* raptor.conf overrides device metadata */
 } ric_config_t;
 
 /* Global state */

--- a/ric/ric_json.c
+++ b/ric/ric_json.c
@@ -235,8 +235,7 @@ static void gpio_led_pin(const cJSON *gpio, const char *key, int *pin, bool *act
 
 void ric_json_gpio_load(ric_config_t *c, const char *path)
 {
-	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0 &&
-	    c->pulse_ms_explicit)
+	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0 && c->pulse_ms_explicit)
 		return;
 
 	FILE *f = fopen(path, "r");
@@ -352,10 +351,8 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 
 	if (c->gpio_ircut >= 0 || c->gpio_irled >= 0)
 		RSS_INFO("GPIOs from %s: ircut=%d ircut2=%d irled=%d irled2=%d pulse=%dms%s%s%s",
-			 path,
-			 c->gpio_ircut, c->gpio_ircut2, c->gpio_irled, c->gpio_irled2,
-			 c->pulse_ms,
-			 c->ircut_active_low ? " ircut-active-low" : "",
+			 path, c->gpio_ircut, c->gpio_ircut2, c->gpio_irled, c->gpio_irled2,
+			 c->pulse_ms, c->ircut_active_low ? " ircut-active-low" : "",
 			 c->irled_active_low ? " irled-active-low" : "",
 			 c->irled2_active_low ? " irled2-active-low" : "");
 }

--- a/ric/ric_json.c
+++ b/ric/ric_json.c
@@ -11,6 +11,9 @@
  *                                (single inverted pin; the object is
  *                                 the standard's only polarity escape
  *                                 hatch, valid for the LED keys too)
+ *   "ircut": {"pin": [52, 53], "delay_us": 100000}
+ *                                (dual-coil pair with its hardware
+ *                                 pulse width; first = day, second = night)
  *   "ir850": 8 / "ir940": 9      (IR LED GPIOs)
  *   -1 or ""                     (explicitly disabled, silent)
  * "ircut": 999 means the board's filter hangs off the tmi8152
@@ -129,6 +132,85 @@ bad:
 	return false;
 }
 
+/* A structured dual-coil description uses one or two bare GPIO
+ * numbers. Per-pin polarity is expressed by pair order for pulse-mode
+ * filters; accepting nested active_low objects here would pretend ric
+ * implements a drive convention it does not. */
+static bool gpio_pin_array(const cJSON *item, int *pin, int *pin2)
+{
+	int n = cJSON_GetArraySize(item);
+	if (n < 1 || n > 2)
+		goto bad;
+	const cJSON *p = cJSON_GetArrayItem(item, 0);
+	if (!cJSON_IsNumber(p) || !valid_gpio(p->valueint))
+		goto bad;
+	*pin = p->valueint;
+	if (n == 2) {
+		p = cJSON_GetArrayItem(item, 1);
+		if (!cJSON_IsNumber(p) || !valid_gpio(p->valueint))
+			goto bad;
+		*pin2 = p->valueint;
+	}
+	return true;
+bad:
+	*pin = -1;
+	*pin2 = -1;
+	RSS_WARN("gpio.ircut.pin array must contain one or two GPIO numbers -- ignored");
+	return false;
+}
+
+/* Parse the structured IR-cut form shared with Thingino's generic
+ * ircut utility. RIC currently implements pulse drive; rejecting any
+ * other named mode is safer than silently applying pulse semantics to
+ * level-sequence hardware. */
+static bool ircut_object_mode_supported(const cJSON *item)
+{
+	const cJSON *mode = cJSON_GetObjectItemCaseSensitive(item, "mode");
+	if (mode && (!cJSON_IsString(mode) || !mode->valuestring ||
+		     strcmp(mode->valuestring, "pulse") != 0)) {
+		RSS_WARN("gpio.ircut mode is not pulse -- unsupported by ric");
+		return false;
+	}
+	return true;
+}
+
+static bool ircut_object(const cJSON *item, int *pin, int *pin2, bool *active_low)
+{
+	const cJSON *p = cJSON_GetObjectItemCaseSensitive(item, "pin");
+	if (cJSON_IsNumber(p)) {
+		if (!valid_gpio(p->valueint))
+			goto bad;
+		*pin = p->valueint;
+		*active_low = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(item, "active_low"));
+		return true;
+	}
+	if (cJSON_IsString(p) && p->valuestring)
+		return gpio_pin_pair(p->valuestring, "ircut.pin", pin, pin2);
+	if (cJSON_IsArray(p))
+		return gpio_pin_array(p, pin, pin2);
+bad:
+	RSS_WARN("gpio.ircut object carries no usable \"pin\" -- ignored");
+	return false;
+}
+
+/* thingino.json records actuator timing in microseconds because the
+ * shell GPIO utility uses usleep. RIC's public setting is milliseconds;
+ * round upward so conversion can never shorten a hardware pulse. */
+static void ircut_object_timing(const cJSON *item, ric_config_t *c)
+{
+	if (c->pulse_ms_explicit)
+		return;
+	const cJSON *delay = cJSON_GetObjectItemCaseSensitive(item, "delay_us");
+	if (!delay)
+		return;
+	if (!cJSON_IsNumber(delay) || delay->valuedouble < 1 || delay->valuedouble > 1000000) {
+		RSS_WARN("gpio.ircut delay_us must be in 1..1000000 -- using %dms", c->pulse_ms);
+		return;
+	}
+	int delay_us = delay->valueint;
+	c->pulse_ms = (delay_us + 999) / 1000;
+}
+
 /* ir850/ir940: a bare number or the {pin, active_low} object. */
 static void gpio_led_pin(const cJSON *gpio, const char *key, int *pin, bool *active_low)
 {
@@ -153,7 +235,8 @@ static void gpio_led_pin(const cJSON *gpio, const char *key, int *pin, bool *act
 
 void ric_json_gpio_load(ric_config_t *c, const char *path)
 {
-	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0)
+	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0 &&
+	    c->pulse_ms_explicit)
 		return;
 
 	FILE *f = fopen(path, "r");
@@ -226,8 +309,12 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 		return;
 	}
 
+	cJSON *ircut = cJSON_GetObjectItemCaseSensitive(gpio, "ircut");
+	bool ircut_object_ok = !cJSON_IsObject(ircut) || ircut_object_mode_supported(ircut);
+	if (cJSON_IsObject(ircut) && ircut_object_ok)
+		ircut_object_timing(ircut, c);
+
 	if (c->gpio_ircut < 0) {
-		cJSON *ircut = cJSON_GetObjectItemCaseSensitive(gpio, "ircut");
 		int pin = -1, pin2 = -1;
 		bool alow = false;
 		if (cJSON_IsNumber(ircut)) {
@@ -240,8 +327,8 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 			else if (ircut->valueint > GPIO_PIN_MAX)
 				RSS_WARN("gpio.ircut %d is out of range -- ignored",
 					 ircut->valueint);
-		} else if (cJSON_IsObject(ircut)) {
-			gpio_object(ircut, "ircut", &pin, &alow);
+		} else if (cJSON_IsObject(ircut) && ircut_object_ok) {
+			ircut_object(ircut, &pin, &pin2, &alow);
 		} else if (cJSON_IsString(ircut) && ircut->valuestring) {
 			gpio_pin_pair(ircut->valuestring, "ircut", &pin, &pin2);
 		}
@@ -264,8 +351,10 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 	cJSON_Delete(root);
 
 	if (c->gpio_ircut >= 0 || c->gpio_irled >= 0)
-		RSS_INFO("GPIOs from %s: ircut=%d ircut2=%d irled=%d irled2=%d%s%s%s", path,
+		RSS_INFO("GPIOs from %s: ircut=%d ircut2=%d irled=%d irled2=%d pulse=%dms%s%s%s",
+			 path,
 			 c->gpio_ircut, c->gpio_ircut2, c->gpio_irled, c->gpio_irled2,
+			 c->pulse_ms,
 			 c->ircut_active_low ? " ircut-active-low" : "",
 			 c->irled_active_low ? " irled-active-low" : "",
 			 c->irled2_active_low ? " irled2-active-low" : "");

--- a/ric/ric_json.h
+++ b/ric/ric_json.h
@@ -7,9 +7,9 @@
 #include "ric.h"
 
 /*
- * Fill any still-unset (-1) IR-cut / IR LED pins in c from the JSON
- * device description at path. A missing file is silent; a file that
- * exists but cannot be used warns.
+ * Fill any still-unset (-1) IR-cut / IR LED pins and non-explicit
+ * actuator timing in c from the JSON device description at path. A
+ * missing file is silent; a file that exists but cannot be used warns.
  */
 void ric_json_gpio_load(ric_config_t *c, const char *path);
 

--- a/ric/ric_main.c
+++ b/ric/ric_main.c
@@ -132,11 +132,13 @@ static void load_config(ric_state_t *st)
 		"poll_interval_ms",
 		rss_config_get_int(cfg, "ircut", "poll_interval_ms", default_poll), 50, 10000);
 
-	/* Dual-GPIO coil pulse. 10ms is what the thingino ircut script has
-	 * driven the whole fleet with since thingino-daynight existed; both
-	 * 10ms and 100ms measured 20/20 reliable on a dual-GPIO Wyze Cam3,
-	 * so the default follows the fleet. Clamped: a zero pulse moves no
-	 * filter, and holding the coil for seconds is a heater. */
+	/* Probe before the getter stores its default. An explicit runtime
+	 * setting is policy and wins over timing in thingino.json; otherwise
+	 * the device description may replace the fleet's 10ms default with
+	 * the actuator's measured pulse width. */
+	c->pulse_ms_explicit = rss_config_get_str(cfg, "ircut", "pulse_ms", NULL) != NULL;
+	/* A zero pulse moves no filter, and holding the coil for seconds is
+	 * a heater. */
 	c->pulse_ms =
 		cfg_clamp("pulse_ms", rss_config_get_int(cfg, "ircut", "pulse_ms", 10), 1, 1000);
 

--- a/tests/test_ric_json.c
+++ b/tests/test_ric_json.c
@@ -34,6 +34,7 @@ static ric_config_t fresh_config(void)
 	c.gpio_ircut2 = -1;
 	c.gpio_irled = -1;
 	c.gpio_irled2 = -1;
+	c.pulse_ms = 10;
 	return c;
 }
 
@@ -90,6 +91,46 @@ TEST ric_json_object_pins(void)
 	ASSERT(c.irled_active_low);
 	ASSERT_EQ(50, c.gpio_irled2);
 	ASSERT_FALSE(c.irled2_active_low);
+	unlink(FIXTURE);
+	PASS();
+}
+
+TEST ric_json_object_pair_and_timing(void)
+{
+	ric_config_t c = fresh_config();
+	const char *j = "{\"gpio\":{\"ircut\":{\"pin\":[52,53],\"delay_us\":100000}}}";
+	write_fixture(j, strlen(j));
+	ric_json_gpio_load(&c, FIXTURE);
+	ASSERT_EQ(52, c.gpio_ircut);
+	ASSERT_EQ(53, c.gpio_ircut2);
+	ASSERT_EQ(100, c.pulse_ms);
+	unlink(FIXTURE);
+	PASS();
+}
+
+TEST ric_json_explicit_timing_wins(void)
+{
+	ric_config_t c = fresh_config();
+	c.pulse_ms = 75;
+	c.pulse_ms_explicit = true;
+	const char *j = "{\"gpio\":{\"ircut\":{\"pin\":[52,53],\"delay_us\":100000}}}";
+	write_fixture(j, strlen(j));
+	ric_json_gpio_load(&c, FIXTURE);
+	ASSERT_EQ(52, c.gpio_ircut);
+	ASSERT_EQ(53, c.gpio_ircut2);
+	ASSERT_EQ(75, c.pulse_ms);
+	unlink(FIXTURE);
+	PASS();
+}
+
+TEST ric_json_unsupported_drive_mode_rejected(void)
+{
+	ric_config_t c = fresh_config();
+	const char *j = "{\"gpio\":{\"ircut\":{\"pin\":[52,53],\"mode\":\"level-sequence\"}}}";
+	write_fixture(j, strlen(j));
+	ric_json_gpio_load(&c, FIXTURE);
+	ASSERT_EQ(-1, c.gpio_ircut);
+	ASSERT_EQ(-1, c.gpio_ircut2);
 	unlink(FIXTURE);
 	PASS();
 }
@@ -364,6 +405,9 @@ SUITE(ric_json_suite)
 	RUN_TEST(ric_json_int_pins);
 	RUN_TEST(ric_json_dual_string_ircut);
 	RUN_TEST(ric_json_object_pins);
+	RUN_TEST(ric_json_object_pair_and_timing);
+	RUN_TEST(ric_json_explicit_timing_wins);
+	RUN_TEST(ric_json_unsupported_drive_mode_rejected);
 	RUN_TEST(ric_json_object_extra_keys_ignored);
 	RUN_TEST(ric_json_object_without_pin_rejected);
 	RUN_TEST(ric_json_plain_form_resets_polarity);


### PR DESCRIPTION
## Root cause

RIC assumed a fixed 10 ms pulse for every dual-GPIO IR-cut actuator. On a Wyze Cam v3 test device, software entered day state but the physical filter intermittently remained in the night position, producing IR-contaminated magenta video. Repeated controlled transitions were reliable at 100 ms.

## Fix

- accept the existing structured Thingino IR-cut metadata form with one or two GPIO pins
- read delay_us and round upward to RIC pulse_ms
- keep an explicit raptor.conf pulse_ms authoritative
- reject non-pulse actuator modes instead of applying incorrect drive semantics
- keep the fleet default at 10 ms when metadata supplies no timing

There is no sensor-name or camera-model conditional in this change. Actuator timing belongs to the board description.

## Validation

- full host test suite: 304 passed, 0 failed
- T31 uClibc cross-build passed
- staged RIC on the affected camera read 100 ms from temporary Thingino metadata
- manual night followed by RIC restart returned reliably to day with neutral color
- original on-device binary and service state restored after the smoke test