### PR TITLE
rod: clamp an OSD region to the frame it goes on

### DIFF
--- a/rod/rod_elem.c
+++ b/rod/rod_elem.c
@@ -211,6 +211,17 @@ void create_elem_shm(rod_state_t *st, rod_element_t *e, int s)
 		return;
 	}
 
+	/*
+	 * Text and receipt sizes are a character count times the font metrics,
+	 * and neither count knows the frame size, so the sizes above are
+	 * unbounded. Clip: text that runs off the region is visible, a region
+	 * larger than the canvas is not.
+	 */
+	if (st->stream_w[s] > 0 && w > (uint32_t)st->stream_w[s])
+		w = (uint32_t)st->stream_w[s];
+	if (st->stream_h[s] > 0 && h > (uint32_t)st->stream_h[s])
+		h = (uint32_t)st->stream_h[s];
+
 	w = (w + 1) & ~1u;
 	h = (h + 1) & ~1u;
 


### PR DESCRIPTION
`create_elem_shm` sizes a region from the element and then creates it. Nothing between those two points compares the result against the picture it goes on.

For text and receipt elements the size is a character count times the font metrics, and neither count knows the frame size. `max_chars` defaults to a ceiling of 128; at `font_size 48` the advance is about 29 px, so one text element asks for roughly **3712 px of width** — on a 1920-wide stream, and on a 640-wide sub-stream. The font scaling in `rod_main.c` does not save it: a sub-stream's font is the main's scaled by the height ratio with a floor of 12, so the character count is still the unbounded term.

This clips both dimensions to the stream's, where the stream's are known. Clipped text is the mild failure and the one it chooses; handing the HAL a region larger than the canvas is the failure that is hard to read back from a log, because what a vendor SDK does with it is its own business — reject, clip, or something worse — and none of those name the element.

Only where the dimension is known: the overlay element already takes the stream's size, and a stream whose size has not been resolved yet is left alone rather than clamped to zero.

### Provenance and verification

Found by raising a board config's font to 48, on hardware that is not Ingenic. What carries across is the arithmetic — the sizing path and both ceilings are shared code, and the same `max_chars` ceiling is reachable from any config.

- built **and linked** for T31 (`mipsel-thingino-linux-uclibc`, gcc 15.3.0), against all four sibling repos at `origin/main`
- `tests/` suite: 301 tests, 0 fail
- clang-format clean

There is no rod host suite to add a case to, so beyond the build this is verified by construction rather than by a test. Happy to add one if you would rather have the harness than the fix on its own.
