### PR TITLE
rhd: reopen a JPEG ring whose producer has been replaced

### DIFF
--- a/rhd/rhd_main.c
+++ b/rhd/rhd_main.c
@@ -949,6 +949,29 @@ static void server_run(rhd_server_t *srv)
 		if (++jpeg_reconnect_tick >= 20) {
 			jpeg_reconnect_tick = 0;
 			for (int j = 0; j < RHD_MAX_JPEG; j++) {
+				/*
+				 * A restarted producer unlinks the name and creates a
+				 * new file, leaving this handle on an orphan whose
+				 * write_seq and incarnation are both frozen -- so
+				 * neither a read nor the idle counter below can tell
+				 * it from a ring that is merely quiet, and only the
+				 * file's identity can. Closing here falls into the
+				 * reopen below, in this same pass.
+				 */
+				if (srv->jpeg_rings[j] && rss_ring_stale(srv->jpeg_rings[j])) {
+					RSS_DEBUG("jpeg ring replaced by a new producer, "
+						  "reopening (%s)",
+						  jpeg_ring_names[j]);
+					if (ring_acquired[j]) {
+						rss_ring_release(srv->jpeg_rings[j]);
+						ring_acquired[j] = false;
+					}
+					rss_ring_close(srv->jpeg_rings[j]);
+					srv->jpeg_rings[j] = NULL;
+					jpeg_idle[j] = 0;
+					jpeg_last_ws[j] = 0;
+				}
+
 				if (!srv->jpeg_rings[j]) {
 					if (jpeg_ring_open_slot(srv, j) && ring_wanted[j]) {
 						rss_ring_acquire(srv->jpeg_rings[j]);


### PR DESCRIPTION
An MJPEG viewer keeps being shown the picture from before an rvd restart for about twenty seconds, and a snapshot taken in that window comes from the same stale picture.

### Why nothing notices

rvd unlinks the shm name when it stops, so a restart creates a new file at the same name while every consumer still mapped holds a private orphan of the old one. Nothing about that orphan changes again:

- `write_seq` is frozen, so a read returns `EAGAIN` and never `EOVERFLOW`
- `incarnation` is frozen too, so the restart signal a consumer is supposed to watch **cannot fire by construction**

The create path is written to avoid exactly this — it reuses the inode and bumps `incarnation` for the purpose — and the unlink at teardown undoes it.

What notices instead is the idle counter in the periodic sweep, which closes the ring after ten ticks for an unrelated reason. Ten ticks is where the twenty seconds comes from, and why the symptom reads as a setting that did not take rather than as a stall.

### The fix

`rss_ring_stale()` compares the mapped file's identity against the name's current one, which is the only thing that can separate an orphan from a ring that is merely quiet. A missing name counts as stale, so a producer that is still coming back up is handled by the same branch. `rsd_ring_reader.c` already asks it after its own idle threshold; rhd never asked at all.

Asked at the top of the sweep that already walks these rings, so the close falls straight into the reopen below it: **no new state, no new field, recovery in one sweep (~2 s) instead of ten (~20 s)**. A parked snapshot is not stranded by it either — the sweep runs after `snap_poll` in the same pass, so the slot is refilled before the next poll looks at it.

### Deliberately not done

A tighter version asks at the read, on a frame-interval clock, and drops the ring the moment it owes a frame. It is worth about half a second over this one and costs a per-ring timestamp plus a change to both read paths. Say the word if you want that shape instead.

### Verification

- built **and linked** for T31 (`mipsel-thingino-linux-uclibc`, gcc 15.3.0), against all four sibling repos at `origin/main`
- `tests/` suite: 301 tests, 0 fail
- clang-format clean

The cause was named on hardware by reading two counters against each other: the ring header says `write_seq` resets to zero on a restart while the file under `/dev/shm` counts up from one, which is only possible if the two are different files. That was after two wrong diagnoses that each looked plausible against the read path alone.
