### PR TITLE
ric: qualify day-mode AE before judging darkness

### DIFF
--- a/ric/ric.h
+++ b/ric/ric.h
@@ -227,13 +227,14 @@ typedef struct {
 	int settle_agree_run;
 	int settle_extend_left;
 
-	/* The first day-mode samples arrive while AE is still climbing from
-	 * its cold-start exposure.  Do not mistake those underexposed frames
-	 * for darkness; arm the normal luma policy once day luma is reached,
-	 * gain proves darkness, or EV has actually settled. */
-	bool startup_ae_settling;
-	uint32_t startup_prev_ev;
-	int startup_ev_agree_run;
+	/* Day-mode samples can arrive while AE is still climbing from its
+	 * reset exposure, both at cold start and after an ISP mode switch.
+	 * Do not mistake those underexposed frames for darkness; arm the
+	 * normal luma policy once day luma is reached, gain proves darkness,
+	 * or EV has actually settled. */
+	bool day_ae_settling;
+	uint32_t day_prev_ev;
+	int day_ev_agree_run;
 
 	/* Photo mode state */
 	ric_photo_state_t photo;

--- a/ric/ric.h
+++ b/ric/ric.h
@@ -227,6 +227,14 @@ typedef struct {
 	int settle_agree_run;
 	int settle_extend_left;
 
+	/* The first day-mode samples arrive while AE is still climbing from
+	 * its cold-start exposure.  Do not mistake those underexposed frames
+	 * for darkness; arm the normal luma policy once day luma is reached,
+	 * gain proves darkness, or EV has actually settled. */
+	bool startup_ae_settling;
+	uint32_t startup_prev_ev;
+	int startup_ev_agree_run;
+
 	/* Photo mode state */
 	ric_photo_state_t photo;
 

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -667,6 +667,39 @@ void ric_poll_exposure(ric_state_t *st)
 		return;
 	}
 
+	/* RVD can become reachable before the sensor's cold-start AE has
+	 * found an exposure.  On T31 this presents as several low-luma,
+	 * minimum-gain frames while exposure and EV are still climbing.  A
+	 * fixed startup delay either races slow AE or needlessly delays a
+	 * genuinely dark boot, so qualify the readings instead:
+	 *
+	 *  - day luma means the day position is already proven;
+	 *  - night gain means the scene is already proven dark;
+	 *  - otherwise, require three successive EV readings within 5%
+	 *    before low luma may enter the normal debounce.
+	 *
+	 * EV covers exposure time as well as gain, unlike the night baseline
+	 * settling check below.  Platforms without EV retain the old behavior
+	 * rather than being held in day indefinitely. */
+	if (st->startup_ae_settling && st->current_mode == RIC_MODE_DAY &&
+	    st->settings.trigger == RIC_TRIGGER_LUMA && have_ev) {
+		bool day_proven = have_luma && ae_luma >= (uint32_t)st->settings.night_luma;
+		bool night_proven = have_gain && total_gain >= (uint32_t)st->settings.night_gain;
+		bool within = st->startup_prev_ev > 0 &&
+			      ev <= st->startup_prev_ev + st->startup_prev_ev / 20 &&
+			      ev >= st->startup_prev_ev - st->startup_prev_ev / 20;
+
+		st->startup_ev_agree_run = within ? st->startup_ev_agree_run + 1 : 0;
+		st->startup_prev_ev = ev;
+		if (!day_proven && !night_proven && st->startup_ev_agree_run < 3) {
+			st->night_count = 0;
+			return;
+		}
+		st->startup_ae_settling = false;
+		RSS_DEBUG("startup AE ready: luma=%u gain=%u ev=%u (%s)", ae_luma, total_gain, ev,
+			  day_proven ? "day luma" : (night_proven ? "night gain" : "settled EV"));
+	}
+
 	bool want_night = false, want_day = false;
 	char why[128];
 

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -420,6 +420,10 @@ void ric_trigger_rearm(ric_state_t *st)
 	st->settle_prev_gain = 0;
 	st->settle_agree_run = 0;
 	st->settle_extend_left = 17;
+	st->day_ae_settling =
+		st->current_mode == RIC_MODE_DAY && st->settings.trigger == RIC_TRIGGER_LUMA;
+	st->day_prev_ev = 0;
+	st->day_ev_agree_run = 0;
 	st->night_gain_baseline = 0;
 	st->night_ev_baseline = 0;
 	st->night_detect_gain = 0;
@@ -462,6 +466,9 @@ void ric_set_mode(ric_state_t *st, ric_mode_t mode)
 	st->settle_prev_gain = 0;
 	st->settle_agree_run = 0;
 	st->settle_extend_left = 17;
+	st->day_ae_settling = mode == RIC_MODE_DAY;
+	st->day_prev_ev = 0;
+	st->day_ev_agree_run = 0;
 	st->probe_recheck_polls = 0; /* re-armed when the baseline lands */
 	if (mode == RIC_MODE_DAY)
 		st->night_gain_baseline = 0;
@@ -510,6 +517,40 @@ static uint32_t json_get_uint(const cJSON *root, const char *key)
 {
 	const cJSON *item = cJSON_GetObjectItem(root, key);
 	return cJSON_IsNumber(item) ? (uint32_t)item->valuedouble : 0;
+}
+
+/* Qualify a day-mode exposure before low luma is allowed to mean night.
+ * Switching ISP mode restarts AE on T31 just like cold start does: the
+ * first frames have minimum gain and exposure, then EV climbs until the
+ * scene is usable. A fixed delay either races slow AE or stalls a real
+ * dark transition, so accept the first of:
+ *
+ *  - luma already proves daylight;
+ *  - gain already proves darkness;
+ *  - three successive EV readings agree within 5%.
+ *
+ * Platforms without EV retain the previous behavior. */
+static bool ric_day_ae_ready(ric_state_t *st, bool have_gain, uint32_t total_gain, bool have_luma,
+			     uint32_t ae_luma, bool have_ev, uint32_t ev)
+{
+	if (!st->day_ae_settling || st->current_mode != RIC_MODE_DAY ||
+	    st->settings.trigger != RIC_TRIGGER_LUMA || !have_ev)
+		return true;
+
+	bool day_proven = have_luma && ae_luma >= (uint32_t)st->settings.night_luma;
+	bool night_proven = have_gain && total_gain >= (uint32_t)st->settings.night_gain;
+	bool within = st->day_prev_ev > 0 && ev <= st->day_prev_ev + st->day_prev_ev / 20 &&
+		      ev >= st->day_prev_ev - st->day_prev_ev / 20;
+
+	st->day_ev_agree_run = within ? st->day_ev_agree_run + 1 : 0;
+	st->day_prev_ev = ev;
+	if (!day_proven && !night_proven && st->day_ev_agree_run < 3)
+		return false;
+
+	st->day_ae_settling = false;
+	RSS_DEBUG("day AE ready: luma=%u gain=%u ev=%u (%s)", ae_luma, total_gain, ev,
+		  day_proven ? "day luma" : (night_proven ? "night gain" : "settled EV"));
+	return true;
 }
 
 /* Poll ISP exposure once and decide the day/night transition. */
@@ -587,6 +628,9 @@ void ric_poll_exposure(ric_state_t *st)
 		st->settings.trigger = RIC_TRIGGER_LUMA;
 	}
 
+	bool day_ae_ready =
+		ric_day_ae_ready(st, have_gain, total_gain, have_luma, ae_luma, have_ev, ev);
+
 	/* Cooldown after mode switch: wait for IR LEDs / ISP to stabilize.
 	 * After cooldown in night mode, sample total_gain as baseline for
 	 * the auto-calibrating night→day transition. */
@@ -594,6 +638,14 @@ void ric_poll_exposure(ric_state_t *st)
 		st->cooldown_remaining--;
 		if (st->cooldown_remaining == 0 && st->current_mode == RIC_MODE_DAY &&
 		    st->day_verify_pending) {
+			/* The ISP mode switch itself restarts AE. Keep the normal
+			 * cooldown alive until the exposure is meaningful; otherwise
+			 * a valid dawn probe is rejected from a few minimum-exposure
+			 * frames before AE has had a chance to climb. */
+			if (!day_ae_ready) {
+				st->cooldown_remaining = 1;
+				return;
+			}
 			st->day_verify_pending = false;
 			if (have_luma && ae_luma < (uint32_t)st->settings.night_luma) {
 				/* The scene reads night-dark with the IR off: the
@@ -667,37 +719,9 @@ void ric_poll_exposure(ric_state_t *st)
 		return;
 	}
 
-	/* RVD can become reachable before the sensor's cold-start AE has
-	 * found an exposure.  On T31 this presents as several low-luma,
-	 * minimum-gain frames while exposure and EV are still climbing.  A
-	 * fixed startup delay either races slow AE or needlessly delays a
-	 * genuinely dark boot, so qualify the readings instead:
-	 *
-	 *  - day luma means the day position is already proven;
-	 *  - night gain means the scene is already proven dark;
-	 *  - otherwise, require three successive EV readings within 5%
-	 *    before low luma may enter the normal debounce.
-	 *
-	 * EV covers exposure time as well as gain, unlike the night baseline
-	 * settling check below.  Platforms without EV retain the old behavior
-	 * rather than being held in day indefinitely. */
-	if (st->startup_ae_settling && st->current_mode == RIC_MODE_DAY &&
-	    st->settings.trigger == RIC_TRIGGER_LUMA && have_ev) {
-		bool day_proven = have_luma && ae_luma >= (uint32_t)st->settings.night_luma;
-		bool night_proven = have_gain && total_gain >= (uint32_t)st->settings.night_gain;
-		bool within = st->startup_prev_ev > 0 &&
-			      ev <= st->startup_prev_ev + st->startup_prev_ev / 20 &&
-			      ev >= st->startup_prev_ev - st->startup_prev_ev / 20;
-
-		st->startup_ev_agree_run = within ? st->startup_ev_agree_run + 1 : 0;
-		st->startup_prev_ev = ev;
-		if (!day_proven && !night_proven && st->startup_ev_agree_run < 3) {
-			st->night_count = 0;
-			return;
-		}
-		st->startup_ae_settling = false;
-		RSS_DEBUG("startup AE ready: luma=%u gain=%u ev=%u (%s)", ae_luma, total_gain, ev,
-			  day_proven ? "day luma" : (night_proven ? "night gain" : "settled EV"));
+	if (!day_ae_ready) {
+		st->night_count = 0;
+		return;
 	}
 
 	bool want_night = false, want_day = false;

--- a/ric/ric_main.c
+++ b/ric/ric_main.c
@@ -652,6 +652,7 @@ int main(int argc, char **argv)
 	}
 
 	/* Apply initial mode -- force GPIOs to known state at startup */
+	st.startup_ae_settling = st.settings.opmode == RIC_AUTO;
 	st.current_mode = RIC_MODE_UNSET;
 	if (st.settings.opmode == RIC_FORCE_DAY)
 		ric_set_mode(&st, RIC_MODE_DAY);

--- a/ric/ric_main.c
+++ b/ric/ric_main.c
@@ -652,7 +652,6 @@ int main(int argc, char **argv)
 	}
 
 	/* Apply initial mode -- force GPIOs to known state at startup */
-	st.startup_ae_settling = st.settings.opmode == RIC_AUTO;
 	st.current_mode = RIC_MODE_UNSET;
 	if (st.settings.opmode == RIC_FORCE_DAY)
 		ric_set_mode(&st, RIC_MODE_DAY);

--- a/tests/ric_harness.py
+++ b/tests/ric_harness.py
@@ -473,7 +473,7 @@ def scenario_startup_ae_walk(stub, watch):
     mm = stub.mark()
     ric = Ric("startup-ae-walk", LUMA_CONF)
     ok = ric.wait_running() and wait_for(
-        lambda: "startup AE ready" in ric.read_log(), 4
+        lambda: "day AE ready" in ric.read_log(), 4
     )
     result(ok, "startup AE walk reaches a qualified reading", ric.read_log())
     modes = stub.modes_since(mm)
@@ -494,6 +494,59 @@ def scenario_startup_dark(stub, watch):
         lambda: "night" in stub.modes_since(mm), 4
     )
     result(ok, "settled dark startup still switches to night", ric.read_log())
+    ric.stop()
+
+
+def scenario_day_switch_ae_walk(stub, watch):
+    """Entering day mode restarts AE. Rising EV after a valid dawn decision
+    must not fail post-switch verification or debounce straight back to night."""
+    stub.set_scene(luma=120, gain=500, ev=4000)
+    ric = Ric("day-switch-ae-walk", LUMA_CONF)
+    if not ric.wait_running():
+        result(False, "day-switch AE walk: ric start", "no 'ric running'")
+        ric.stop()
+        return
+    time.sleep(0.5)
+
+    mm = stub.mark()
+    stub.set_scene(luma=5, gain=20000, ev=100000)
+    if not wait_for(lambda: "night" in stub.modes_since(mm), 4):
+        result(False, "day-switch AE walk: night entry", ric.read_log())
+        ric.stop()
+        return
+
+    # Let the IR-lit night reading become the baseline, then present dawn
+    # below the ratio threshold. The mode switch resets AE to a string of
+    # underexposed frames before daylight luma returns.
+    time.sleep((3 + 2) * POLL_MS / 1000.0)
+    mm = stub.mark()
+    stub.set_scene(luma=50, gain=4000, ev=20000)
+    if not wait_for(lambda: "day" in stub.modes_since(mm), 4):
+        result(False, "day-switch AE walk: day entry", ric.read_log())
+        ric.stop()
+        return
+
+    dm = stub.mark()
+    stub.set_scene_sequence([
+        {"luma": 4, "gain": 256, "ev": 45},
+        {"luma": 5, "gain": 256, "ev": 50},
+        {"luma": 6, "gain": 257, "ev": 56},
+        {"luma": 8, "gain": 256, "ev": 63},
+        {"luma": 11, "gain": 256, "ev": 71},
+        {"luma": 14, "gain": 257, "ev": 80},
+        {"luma": 17, "gain": 256, "ev": 90},
+        {"luma": 19, "gain": 256, "ev": 101},
+        {"luma": 21, "gain": 256, "ev": 113},
+        {"luma": 30, "gain": 256, "ev": 140},
+    ])
+    ok = wait_for(lambda: "day AE ready" in ric.read_log(), 4)
+    result(ok, "day-switch AE walk reaches a qualified reading", ric.read_log())
+    modes = stub.modes_since(dm)
+    result(
+        "night" not in modes and ric_status().get("state") == "day",
+        "day-switch AE walk does not reject a valid dawn",
+        "modes=%s log=%s" % (modes, ric.read_log()),
+    )
     ric.stop()
 
 
@@ -2446,6 +2499,7 @@ def main():
         scenario_startup_park,
         scenario_startup_ae_walk,
         scenario_startup_dark,
+        scenario_day_switch_ae_walk,
         scenario_dusk_dawn,
         scenario_hysteresis,
         scenario_cooldown,

--- a/tests/ric_harness.py
+++ b/tests/ric_harness.py
@@ -142,6 +142,7 @@ class StubRvd:
 
     def __init__(self):
         self.scene = {}
+        self.scene_queue = []
         self.modes = []  # (monotonic, "day"|"night")
         self.fps_calls = []  # (monotonic, int value) from set-sensor-fps
         self.fps_error = False  # answer set-sensor-fps with an error
@@ -172,6 +173,13 @@ class StubRvd:
     def set_scene(self, **kw):
         with self.lock:
             self.scene = dict(kw)
+            self.scene_queue = []
+
+    def set_scene_sequence(self, scenes):
+        """Return one scripted exposure per query, then hold the last."""
+        with self.lock:
+            self.scene_queue = [dict(sc) for sc in scenes]
+            self.scene = dict(scenes[-1])
 
     def mark(self):
         with self.lock:
@@ -203,7 +211,10 @@ class StubRvd:
                 cmd = json.loads(req).get("cmd", "")
                 if cmd == "get-exposure":
                     with self.lock:
-                        sc = dict(self.scene)
+                        if self.scene_queue:
+                            sc = self.scene_queue.pop(0)
+                        else:
+                            sc = dict(self.scene)
                     resp = {
                         "total_gain": sc.get("gain", 0),
                         "exposure_us": sc.get("exposure_us", 10000),
@@ -440,6 +451,49 @@ def scenario_startup_park(stub, watch):
             "gpio directions set to out",
             str(dirs),
         )
+    ric.stop()
+
+
+def scenario_startup_ae_walk(stub, watch):
+    """RVD is live before cold-start AE reaches a daylight exposure.
+    Rising EV must not be counted as consecutive night samples."""
+    samples = [
+        {"luma": 4, "gain": 256, "ev": 45},
+        {"luma": 5, "gain": 256, "ev": 50},
+        {"luma": 6, "gain": 257, "ev": 56},
+        {"luma": 8, "gain": 256, "ev": 63},
+        {"luma": 11, "gain": 256, "ev": 71},
+        {"luma": 14, "gain": 257, "ev": 80},
+        {"luma": 17, "gain": 256, "ev": 90},
+        {"luma": 19, "gain": 256, "ev": 101},
+        {"luma": 21, "gain": 256, "ev": 113},
+        {"luma": 30, "gain": 256, "ev": 140},
+    ]
+    stub.set_scene_sequence(samples)
+    mm = stub.mark()
+    ric = Ric("startup-ae-walk", LUMA_CONF)
+    ok = ric.wait_running() and wait_for(
+        lambda: "startup AE ready" in ric.read_log(), 4
+    )
+    result(ok, "startup AE walk reaches a qualified reading", ric.read_log())
+    modes = stub.modes_since(mm)
+    result(
+        "night" not in modes and ric_status().get("state") == "day",
+        "startup AE walk does not cause a false night switch",
+        "modes=%s log=%s" % (modes, ric.read_log()),
+    )
+    ric.stop()
+
+
+def scenario_startup_dark(stub, watch):
+    """The startup guard must still admit a genuinely dark, settled scene."""
+    stub.set_scene(luma=5, gain=20000, ev=100000)
+    mm = stub.mark()
+    ric = Ric("startup-dark", LUMA_CONF)
+    ok = ric.wait_running() and wait_for(
+        lambda: "night" in stub.modes_since(mm), 4
+    )
+    result(ok, "settled dark startup still switches to night", ric.read_log())
     ric.stop()
 
 
@@ -2390,6 +2444,8 @@ def main():
 
     scenarios = [
         scenario_startup_park,
+        scenario_startup_ae_walk,
+        scenario_startup_dark,
         scenario_dusk_dawn,
         scenario_hysteresis,
         scenario_cooldown,


### PR DESCRIPTION
## Problem

RIC can receive valid but underexposed day-mode frames while AE is still climbing:

- at cold start, RVD becomes reachable before exposure is ready;
- after an automatic night-to-day transition, changing the ISP running mode restarts AE.

In both cases the existing three-poll cooldown can expire while gain and exposure are still near minimum. Low luma then either fills the normal night debounce or fails the post-switch IR-reflection check, sending a daylight camera back to night.

The second path was reproduced on a live T31/OpenIMP VDB2. RIC correctly detected dawn at luma 42, switched to day, then rejected it three seconds later at luma 12. A forced day transition showed luma 10 / gain 270 / exposure 260 us / EV 13 after six seconds, then recovered to luma 58 as exposure climbed. The IR-cut pulse was already 100 ms and the filter moved, so this was not an actuator or board-metadata failure.

## Fix

Qualify every automatic day-mode exposure without adding a fixed delay or a sensor-specific setting:

- accept immediately when luma proves day;
- accept immediately when gain proves night;
- otherwise require three successive EV readings within 5 percent before low luma may enter the normal debounce or post-switch verification.

EV is used because it follows exposure time as well as gain. Forced modes, non-luma triggers, and platforms without EV keep their existing behavior. The same guard is re-armed after a live trigger change while the camera is in day mode.

## Validation

- ASan/UBSan focused host build: pass
- full RIC hardware-sandbox behavior suite: 176 pass, 0 fail
- regression for rising daylight EV at cold start: pass
- regression for valid dawn followed by an ISP-reset AE walk: pass
- stable dark startup, covered-lens rejection, slow-AE probes, GPIO failures, and recovery scenarios: pass
- exact clang-format-19 PR gate and diff checks: pass

This remains independent of the IR-cut metadata work in #38; both are included by the integration branch.
