### PR TITLE
rhd: take back the slot from a client that never asks for anything

### DIFF
--- a/rhd/rhd.h
+++ b/rhd/rhd.h
@@ -33,9 +33,10 @@
 #define RHD_MAX_CLIENTS	    8
 #define RHD_RECV_BUF	    4096
 #define RHD_MJPEG_BOUNDARY  "raptorframe"
-#define RHD_SEND_TIMEOUT_MS 3000 /* max time to drain a one-shot response */
-#define RHD_SNAP_TIMEOUT_MS 5000 /* max wait for a JPEG encoder to produce a fresh frame */
-#define RHD_MAX_JPEG	    6	 /* up to 2 per sensor, 3 sensors */
+#define RHD_SEND_TIMEOUT_MS 3000  /* max time to drain a one-shot response */
+#define RHD_RECV_TIMEOUT_MS 10000 /* max time a client may take to finish its request */
+#define RHD_SNAP_TIMEOUT_MS 5000  /* max wait for a JPEG encoder to produce a fresh frame */
+#define RHD_MAX_JPEG	    6	  /* up to 2 per sensor, 3 sensors */
 
 /* Index page — loaded from file on first request, cached */
 #define RHD_INDEX_PATH "/usr/share/raptor/index.html"
@@ -78,6 +79,7 @@ typedef struct {
 	struct sockaddr_storage addr;
 	char recv_buf[RHD_RECV_BUF];
 	size_t recv_len;
+	int64_t recv_start; /* monotonic ms a still-reading client connected at */
 
 	/*
 	 * Parked /snap request. An idle JPEG encoder needs a frame period or
@@ -107,6 +109,20 @@ typedef struct {
 	pthread_t send_tid;
 	bool send_thread_running;
 } rhd_client_t;
+
+/*
+ * True for a client that connected, took a slot, and has still not asked for
+ * anything. There are only RHD_MAX_CLIENTS slots and nothing else bounds this
+ * state: a stream, a parked snapshot and a draining response each carry their
+ * own deadline, so none of them are still reading a request and none are
+ * reaped here.
+ */
+static inline bool rhd_client_recv_expired(const rhd_client_t *c, int64_t now)
+{
+	if (c->is_mjpeg || c->is_audio || c->send_buf || c->snap_pending)
+		return false;
+	return now - c->recv_start > RHD_RECV_TIMEOUT_MS;
+}
 
 typedef struct {
 	int listen_fd;

--- a/rhd/rhd_main.c
+++ b/rhd/rhd_main.c
@@ -839,6 +839,12 @@ static void server_run(rhd_server_t *srv)
 					continue;
 				}
 				c->fd = cfd;
+				{
+					struct timespec ts;
+					clock_gettime(CLOCK_MONOTONIC, &ts);
+					c->recv_start =
+						(int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+				}
 				memcpy(&c->addr, &sa, sizeof(c->addr));
 #ifdef RSS_HAS_TLS
 				c->srv_tls = srv->tls;
@@ -922,15 +928,24 @@ static void server_run(rhd_server_t *srv)
 			}
 		}
 
-		/* Reap stalled async sends */
+		/* Reap stalled async sends and clients still owing a request */
 		{
 			struct timespec ts;
 			clock_gettime(CLOCK_MONOTONIC, &ts);
 			int64_t now = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 			for (int i = srv->client_count - 1; i >= 0; i--) {
 				rhd_client_t *c = srv->clients[i];
-				if (c->send_buf && (now - c->send_start) > RHD_SEND_TIMEOUT_MS)
+				if (c->send_buf && (now - c->send_start) > RHD_SEND_TIMEOUT_MS) {
 					remove_client(srv, i);
+					continue;
+				}
+				if (rhd_client_recv_expired(c, now)) {
+					char addrstr[INET6_ADDRSTRLEN];
+					client_addr_str(&c->addr, addrstr, sizeof(addrstr));
+					RSS_WARN("dropped %s:%u (no request within %d ms)", addrstr,
+						 client_port(&c->addr), RHD_RECV_TIMEOUT_MS);
+					remove_client(srv, i);
+				}
 			}
 		}
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,7 +22,7 @@ LDFLAGS = $(SAN_FLAGS) -lpthread -lrt -lm
 
 TEST_SRCS = main.c test_ric_json.c test_nal.c test_prebuf.c test_mux.c test_codec.c test_sdp.c test_ring.c test_rsp.c \
             test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_rad_clock.c test_resync.c \
-            test_backchannel.c test_config.c
+            test_backchannel.c test_config.c test_rhd_slots.c
 LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
            ../../raptor-common/src/rss_util.c ../../raptor-common/src/rss_log.c \
            ../../raptor-common/src/cJSON.c \
@@ -40,7 +40,14 @@ SDP_SRC = sdp_parse.c
 $(SDP_SRC): ../rwd/rwd_sdp.c
 	sed '/^int rwd_sdp_generate_answer/,$$d' $< > $@
 
-tests: $(TEST_SRCS) $(LIB_SRCS) $(CTRL_SRCS) $(IPC_SRCS) $(SDP_SRC) greatest.h
+# Headers too. The suite compiles every source in one command, so there are no
+# object files to carry -MMD dependencies -- which means a header change leaves
+# the binary silently stale, and a test asserting something about a header goes
+# on asserting the old value.
+TEST_HDRS = $(wildcard *.h ../*/*.h ../../raptor-hal/include/*.h \
+                       ../../raptor-common/include/*.h ../../raptor-ipc/include/*.h)
+
+tests: $(TEST_SRCS) $(LIB_SRCS) $(CTRL_SRCS) $(IPC_SRCS) $(SDP_SRC) $(TEST_HDRS)
 	$(CC) $(CFLAGS) -DRWD_H -include ../fuzz/fuzz_rwd_shim.h \
 		-o $@ $(TEST_SRCS) $(LIB_SRCS) $(CTRL_SRCS) $(IPC_SRCS) $(SDP_SRC) $(LDFLAGS)
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -23,6 +23,7 @@ extern SUITE(rad_clock_suite);
 extern SUITE(resync_suite);
 extern SUITE(backchannel_suite);
 extern SUITE(config_suite);
+extern SUITE(rhd_slots_suite);
 
 GREATEST_MAIN_DEFS();
 
@@ -52,5 +53,6 @@ int main(int argc, char **argv)
 	RUN_SUITE(resync_suite);
 	RUN_SUITE(backchannel_suite);
 	RUN_SUITE(config_suite);
+	RUN_SUITE(rhd_slots_suite);
 	GREATEST_MAIN_END();
 }

--- a/tests/test_rhd_slots.c
+++ b/tests/test_rhd_slots.c
@@ -1,0 +1,136 @@
+/*
+ * test_rhd_slots.c -- who is allowed to keep holding one of the eight slots
+ *
+ * A camera serves RHD_MAX_CLIENTS connections at once and refuses the ninth
+ * with 503. Before this, the only connection the daemon ever took a slot back
+ * from on its own was one it was mid-reply to; a connection that opened and
+ * then said nothing kept its slot until the daemon restarted. Eight of those
+ * cost nothing to make and turned off snapshots, MJPEG and the console.
+ *
+ * So the question each of these asks is the same one: is this client still
+ * owing the server a request, or is it in some state that already carries its
+ * own deadline? Only the first kind may be dropped for going quiet. The four
+ * tests that say "kept" are the ones that matter -- a timeout that also reaped
+ * live streams would be a worse bug than the one it replaced.
+ *
+ * Time is passed in rather than waited for; nothing here sleeps.
+ */
+#include <string.h>
+
+#include "greatest.h"
+
+#include "../rhd/rhd.h"
+
+/* A client that connected at t=0 and has done nothing since. */
+static rhd_client_t at_rest(void)
+{
+	rhd_client_t c;
+	memset(&c, 0, sizeof(c));
+	c.recv_start = 0;
+	return c;
+}
+
+static const int64_t LATE = RHD_RECV_TIMEOUT_MS + 1;
+
+TEST a_client_that_never_asks_for_anything_is_dropped(void)
+{
+	rhd_client_t c = at_rest();
+
+	ASSERT(rhd_client_recv_expired(&c, LATE));
+	PASS();
+}
+
+/*
+ * The half-open connection does not have to be silent. Sending a request line
+ * and stopping short of the blank line that ends the headers is the cheaper
+ * attack, because it looks like a real client to anything watching bytes.
+ */
+TEST a_half_sent_request_does_not_buy_more_time(void)
+{
+	rhd_client_t c = at_rest();
+	const char *partial = "GET / HTTP/1.1\r\n";
+
+	memcpy(c.recv_buf, partial, strlen(partial));
+	c.recv_len = strlen(partial);
+
+	ASSERT(rhd_client_recv_expired(&c, LATE));
+	PASS();
+}
+
+/*
+ * The window is for a real client on a bad link, so it has to be a window and
+ * not a race: a request still arriving is not late.
+ */
+TEST a_client_still_within_the_window_is_kept(void)
+{
+	rhd_client_t c = at_rest();
+
+	ASSERT_FALSE(rhd_client_recv_expired(&c, RHD_RECV_TIMEOUT_MS / 2));
+	ASSERTm("the deadline itself is not yet past",
+		!rhd_client_recv_expired(&c, RHD_RECV_TIMEOUT_MS));
+	PASS();
+}
+
+/*
+ * An MJPEG client asks once and then holds the connection open for hours by
+ * design. It is the obvious thing to break here.
+ */
+TEST an_mjpeg_stream_is_kept(void)
+{
+	rhd_client_t c = at_rest();
+	c.is_mjpeg = true;
+
+	ASSERT_FALSE(rhd_client_recv_expired(&c, LATE));
+	PASS();
+}
+
+TEST an_audio_stream_is_kept(void)
+{
+	rhd_client_t c = at_rest();
+	c.is_audio = true;
+
+	ASSERT_FALSE(rhd_client_recv_expired(&c, LATE));
+	PASS();
+}
+
+/*
+ * A parked /snap is waiting on an idle JPEG encoder, not on the client, and
+ * RHD_SNAP_TIMEOUT_MS already bounds it.
+ */
+TEST a_parked_snapshot_is_kept(void)
+{
+	rhd_client_t c = at_rest();
+	c.snap_pending = true;
+	c.snap_deadline = LATE + RHD_SNAP_TIMEOUT_MS;
+
+	ASSERT_FALSE(rhd_client_recv_expired(&c, LATE));
+	PASS();
+}
+
+/*
+ * A response still draining belongs to RHD_SEND_TIMEOUT_MS, which is shorter
+ * than this one; reaping it here would take the connection away mid-reply.
+ */
+TEST a_draining_response_is_kept(void)
+{
+	rhd_client_t c = at_rest();
+	uint8_t body[] = "HTTP/1.1 200 OK\r\n\r\n";
+
+	c.send_buf = body;
+	c.send_len = sizeof(body);
+	c.send_start = LATE;
+
+	ASSERT_FALSE(rhd_client_recv_expired(&c, LATE));
+	PASS();
+}
+
+SUITE(rhd_slots_suite)
+{
+	RUN_TEST(a_client_that_never_asks_for_anything_is_dropped);
+	RUN_TEST(a_half_sent_request_does_not_buy_more_time);
+	RUN_TEST(a_client_still_within_the_window_is_kept);
+	RUN_TEST(an_mjpeg_stream_is_kept);
+	RUN_TEST(an_audio_stream_is_kept);
+	RUN_TEST(a_parked_snapshot_is_kept);
+	RUN_TEST(a_draining_response_is_kept);
+}


### PR DESCRIPTION
**Eight TCP connections that never send a request take the HTTP daemon down
until it is restarted.** No credentials needed.

A camera serves `RHD_MAX_CLIENTS` (8) connections at once and refuses the ninth
with 503. The only connection rhd ever reclaims on its own is one it is mid-reply
to: `RHD_SEND_TIMEOUT_MS` is armed when `send_buf` becomes non-NULL, and nothing
bounds how long a client may sit in a slot before that.

Reproduced on an armv7 camera — eight sockets sending `GET / HTTP/1.1\r\n` and
never the blank line that ends the headers:

| t | `GET /` | before | after |
|---|---|---|---|
| +1 s | | 503 | 503 |
| +4 s | | 503 | 503 |
| +11 s | | 503 | **200** |

Snapshots, MJPEG and the index page are all gone for the duration. It does not
even take the partial request line — eight bare `connect()`s do it, because the
slot is taken at `accept()` and nothing in the loop looks at a client that has
not yet spoken.

**The fix** is one predicate; what it *excludes* is the point of it:

```c
static inline bool rhd_client_recv_expired(const rhd_client_t *c, int64_t now)
{
	if (c->is_mjpeg || c->is_audio || c->send_buf || c->snap_pending)
		return false;
	return now - c->recv_start > RHD_RECV_TIMEOUT_MS;
}
```

A stream, a parked snapshot and a draining response are each already bounded by
something else and none are reading a request. A timeout that also reaped live
MJPEG would be a worse bug than the one it replaces, so each of the four terms
has its own test.

Ten seconds because the window has to fit a real client on a bad link rather
than be a race: a connection that trickled its headers over seven seconds is
served 200. The sweep runs on the existing loop pass, so granularity is the idle
`epoll_wait` timeout of 500 ms — nothing a 10 s deadline is sensitive to.

**Tests** — `tests/test_rhd_slots.c`, 7 tests, nothing sleeps (time is passed in).
Every mutation is caught:

| mutation | tests that fail |
|---|---|
| `return false` (the original bug) | the two "dropped" tests |
| guard removed (everything expires) | all four `..._is_kept` |
| drop `is_mjpeg` / `is_audio` / `send_buf` / `snap_pending` | exactly that one's test |
| `>` → `>=` | `a_client_still_within_the_window_is_kept` |

Suite: **308 pass, 0 fail, 0 skip.**

**One build change, and it is load-bearing here.** The suite compiles every
source in one command, so there are no object files to carry `-MMD` deps — a
header change left the binary silently stale. Since the predicate under test
lives in `rhd.h`, running the mutation table without this reports all seven
mutations as passing. `tests:` now depends on the headers too.

**What this does not buy.** It bounds the outage to the length of an attack
rather than to the uptime of the daemon — stop connecting and the camera is back
in ten seconds. A client willing to keep reconnecting can still occupy the eight
slots, as against any server with a connection limit; that wants per-source
connection accounting, which is a different change.

**Heads up on conflicts:** #41 also touches `rhd_main.c` and adds an
`rhd_now_ms()` helper. I deliberately used the existing inline `clock_gettime`
pattern here rather than that helper, so the two should not collide — happy to
rebase onto whichever lands first.

**Verification.** Behaviour measured on hardware before and after, as above; the
MJPEG regression check held a stream open across the window (25 s, 4.2 MB, no
pause) and `/snap` still answers 200.
