### PR TITLE
rvd: round a bad ring slot count instead of dying on it

### DIFF
--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -172,6 +172,8 @@ video_device = /dev/video0
 
 [ring]
 # refmode = false              # zero-copy: encoder writes to shared memory, ring is metadata-only
+# Slot counts must be a power of two, 2..64. A value that is not one is
+# rounded down, with a warning naming the key.
 # main_slots = 32
 # main_data_mb = 0            # 0 = auto-size from bitrate (recommended)
 # sub_slots = 32

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -394,6 +394,37 @@ static void get_ring_name(int sensor_idx, const char *type, char *buf, size_t le
 		snprintf(buf, len, "s%d_%s", sensor_idx, type);
 }
 
+/*
+ * clamp_ring_slots -- force a configured slot count into what the ring accepts.
+ *
+ * rss_ring_create takes a power-of-two count no greater than
+ * RSS_RING_MAX_SLOTS and rejects everything else by returning NULL, which
+ * reaches the caller as a fatal "failed to create ring <name>" naming neither
+ * the key nor the constraint. Round instead, and name both.
+ *
+ * Down rather than up, so a fixed-up value never costs more memory than the
+ * one that was asked for -- these boards are sized to their rings.
+ */
+static int clamp_ring_slots(int slots, const char *key)
+{
+	int orig = slots;
+	int pow2 = 1;
+
+	if (slots < 2)
+		slots = 2;
+	if (slots > RSS_RING_MAX_SLOTS)
+		slots = RSS_RING_MAX_SLOTS;
+
+	while (pow2 * 2 <= slots)
+		pow2 *= 2;
+
+	if (pow2 != orig)
+		RSS_WARN("[ring] %s = %d is not a power of two in 2..%d, using %d", key, orig,
+			 RSS_RING_MAX_SLOTS, pow2);
+
+	return pow2;
+}
+
 /* OSD pool sizing callback — estimates per-element region bytes */
 struct osd_pool_ctx {
 	rss_config_t *cfg;
@@ -1451,8 +1482,17 @@ create_ring:
 			const char *type = is_main ? "main" : "sub";
 			get_ring_name(s->sensor_idx, type, ring_name, sizeof(ring_name));
 
-			int slots_cfg = rss_config_get_int(
-				cfg, "ring", is_main ? "main_slots" : "sub_slots", 32);
+			const char *slots_key = is_main ? "main_slots" : "sub_slots";
+			int slots_cfg = rss_config_get_int(cfg, "ring", slots_key, 32);
+			/*
+			 * rss_ring_create takes only a power-of-two slot count, and
+			 * signals a bad one by returning NULL -- which arrives here as
+			 * a fatal "failed to create ring". A config typo should not
+			 * stop the daemon at startup with an error naming the wrong
+			 * thing, so fix it up and say exactly what was done. Rounding
+			 * down keeps the footprint at or under what was asked for.
+			 */
+			slots_cfg = clamp_ring_slots(slots_cfg, slots_key);
 			int mb_cfg = rss_config_get_int(
 				cfg, "ring", is_main ? "main_data_mb" : "sub_data_mb", 0);
 			uint32_t min_data = is_main ? (256 * 1024) : (128 * 1024);


### PR DESCRIPTION
A `[ring]` slot count that is not a power of two stops rvd at startup with an
error naming neither the key at fault nor the constraint it broke:

```
failed to create ring main
stream0 init failed: -1
pipeline init failed: -1
```

`rss_ring_create` takes a power-of-two count no greater than
`RSS_RING_MAX_SLOTS` (64) and rejects everything else by returning NULL; rvd
treats a ring it cannot create as fatal. The MI pipeline comes up and tears down
cleanly around it in dmesg, which points at the video path and away from the
actual cause. It cost an afternoon to find, and the constraint is not written
down anywhere someone editing the config would look.

`clamp_ring_slots` rounds the value into range and logs the key, the value and
the limit:

```
[ring] main_slots = 24 is not a power of two in 2..64, using 16
```

Down rather than up for anything in range, so a fixed-up value never costs more
memory than was asked for — these boards are sized to their rings, and someone
hand-tuning slot counts is usually trying to spend less. Below the minimum there
is nothing to round to, so 1, 0 and negatives become 2.

Checked across the range: `24 -> 16`, `33 -> 32`, `63 -> 32`, `65 -> 64`,
`100000 -> 64`, `1/0/-5 -> 2`, and `2` and `32` pass through silently with no
warning.

`config/raptor.conf` now states the constraint in the `[ring]` section, since a
comment showing `32` does not tell you what else is allowed.

**Scope note.** `rfs` reads `video_slots` and `audio_slots` the same way and has
the same failure. I left it out to keep this to one daemon — happy to follow up
if you want it covered.
