### PR TITLE
rmr: preallocate recording files and publish via rename

### DIFF
--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -396,6 +396,10 @@ position = bottom_right
 # storage_path = /mnt/mmcblk0p1/raptor  # auto-created when on mounted media
 #                             # (SD/NFS/SMB); never auto-created on the root fs
 # max_storage_mb = 0
+# prealloc_mb = 0             # reserve N MB per segment at open; shrink on
+                              # close. 0 = grow organically. The reservation
+                              # is metadata-only on vfat/exfat (no data
+                              # written until recorded frames fill it)
 # prebuffer_sec = 5           # seconds of pre-event footage in motion clips (0-5)
 # clip_length_sec = 60        # motion clip max duration before rotation
 # clip_max_mb = 100           # max total clip storage

--- a/rmr/rmr_main.c
+++ b/rmr/rmr_main.c
@@ -180,7 +180,7 @@ static int start_segment(rmr_state_t *st)
 
 	st->mux = rmr_mux_create(direct_write, st);
 	if (!st->mux) {
-		rmr_storage_close_segment(fd);
+		rmr_storage_close_segment(fd, st->segment_path, 0);
 		return -1;
 	}
 
@@ -215,7 +215,7 @@ static void close_segment(rmr_state_t *st)
 	st->segment_fd = -1;
 
 	if (fd >= 0) {
-		rmr_storage_close_segment(fd);
+		rmr_storage_close_segment(fd, st->segment_path, st->bytes_written);
 		RSS_DEBUG("segment closed: %s (%" PRIu64 " frames, %" PRIu64 " bytes)",
 			  st->segment_path, st->frames_written, st->bytes_written);
 	}
@@ -234,7 +234,7 @@ static int open_clip(rmr_state_t *st)
 
 	st->clip_mux = rmr_mux_create(clip_write, st);
 	if (!st->clip_mux) {
-		rmr_storage_close_segment(fd);
+		rmr_storage_close_segment(fd, st->clip_path, 0);
 		return -1;
 	}
 
@@ -266,7 +266,7 @@ static void close_clip(rmr_state_t *st)
 		st->clip_mux = NULL;
 	}
 	if (st->clip_fd >= 0) {
-		rmr_storage_close_segment(st->clip_fd);
+		rmr_storage_close_segment(st->clip_fd, st->clip_path, st->clip_bytes);
 		RSS_DEBUG("motion clip closed: %s (%" PRIu64 " bytes)", st->clip_path,
 			  st->clip_bytes);
 		st->clip_fd = -1;
@@ -295,7 +295,7 @@ static void close_timelapse(rmr_state_t *st)
 		st->tl_mux = NULL;
 	}
 	if (st->tl_fd >= 0) {
-		rmr_storage_close_segment(st->tl_fd);
+		rmr_storage_close_segment(st->tl_fd, st->tl_path, st->tl_bytes);
 		RSS_INFO("timelapse file closed: %s (%u frames, %" PRIu64 " bytes)", st->tl_path,
 			 st->tl.frames_in_file, st->tl_bytes);
 		st->tl_fd = -1;
@@ -322,7 +322,7 @@ static int open_timelapse(rmr_state_t *st, int32_t day)
 
 	st->tl_mux = rmr_mux_create(tl_write, st);
 	if (!st->tl_mux) {
-		rmr_storage_close_segment(fd);
+		rmr_storage_close_segment(fd, st->tl_path, 0);
 		return -1;
 	}
 
@@ -1370,6 +1370,9 @@ int main(int argc, char **argv)
 		.segment_minutes = rss_config_get_int(dctx.cfg, "recording", "segment_minutes", 5),
 		.segment_seconds = rss_config_get_int(dctx.cfg, "recording", "segment_seconds", 0),
 		.max_storage_mb = rss_config_get_int(dctx.cfg, "recording", "max_storage_mb", 0),
+		.prealloc_bytes =
+			(uint64_t)rss_config_get_int(dctx.cfg, "recording", "prealloc_mb", 0) *
+			1024ULL * 1024ULL,
 	};
 	st.storage = rmr_storage_create(&scfg);
 	if (!st.storage) {

--- a/rmr/rmr_storage.c
+++ b/rmr/rmr_storage.c
@@ -13,18 +13,24 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <time.h>
 #include <unistd.h>
 
+#define RMR_TMP_SUFFIX	   ".tmp"
+#define RMR_TMP_SUFFIX_LEN (sizeof(RMR_TMP_SUFFIX) - 1)
+
 struct rmr_storage {
 	char base_path[256];
 	int segment_minutes;
 	int segment_seconds;
 	int max_storage_mb;
+	uint64_t prealloc_bytes;   /* segment reservation, 0 = none        */
 	bool refuse_logged;	   /* rootfs auto-create refusal logged once */
+	bool swept;		   /* stale .tmp sweep done once            */
 	int64_t last_wait_warn_us; /* rate-limit for the waiting log       */
 };
 
@@ -41,6 +47,7 @@ rmr_storage_t *rmr_storage_create(const rmr_storage_config_t *cfg)
 	st->segment_minutes = cfg->segment_minutes > 0 ? cfg->segment_minutes : 5;
 	st->segment_seconds = cfg->segment_seconds;
 	st->max_storage_mb = cfg->max_storage_mb;
+	st->prealloc_bytes = cfg->prealloc_bytes;
 
 	return st;
 }
@@ -65,22 +72,68 @@ int rmr_storage_open_segment(rmr_storage_t *st, char *path_out, int path_out_siz
 		 tm.tm_mon + 1, tm.tm_mday);
 	rss_mkdir_p(dir);
 
-	/* Filename: HH-MM-SS.mp4 */
+	/* Final name: HH-MM-SS.mp4. Recording happens under a .tmp twin
+	 * of that name; the .mp4 appears only when the segment closes
+	 * cleanly (rename), so a power loss mid-segment can never leave
+	 * a truncated .mp4 behind for players and NVR importers to trip
+	 * over — only the .tmp, which is swept at the next start. */
 	snprintf(path_out, path_out_size, "%s/%02d-%02d-%02d.mp4", dir, tm.tm_hour, tm.tm_min,
 		 tm.tm_sec);
 
-	int fd = open(path_out, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-	if (fd < 0)
-		RSS_ERROR("failed to open segment: %s", path_out);
+	char tmp_path[320];
+	snprintf(tmp_path, sizeof(tmp_path), "%s" RMR_TMP_SUFFIX, path_out);
+
+	int fd = open(tmp_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (fd < 0) {
+		RSS_ERROR("failed to open segment: %s", tmp_path);
+		return -1;
+	}
+
+	/* Optional reservation. ftruncate, never fallocate: vfat rejects
+	 * fallocate (EOPNOTSUPP) and exfat-nofuse does not implement it,
+	 * while their truncate-growth path (fat_cont_expand) only writes
+	 * metadata — the reserved clusters are never touched, so a later
+	 * power loss cannot splice garbage from an old recording into
+	 * this one, and a yanked card keeps its old data intact. A
+	 * failed reservation (e.g. card nearly full) only logs: the
+	 * segment still records, growing organically. */
+	if (st->prealloc_bytes > 0 && ftruncate(fd, (off_t)st->prealloc_bytes) != 0)
+		RSS_WARN("segment prealloc of %llu bytes failed (%s): growing organically",
+			 (unsigned long long)st->prealloc_bytes, strerror(errno));
 
 	return fd;
 }
 
-void rmr_storage_close_segment(int fd)
+void rmr_storage_close_segment(int fd, const char *path, uint64_t bytes)
 {
-	if (fd >= 0) {
-		fsync(fd);
+	if (fd < 0)
+		return;
+
+	if (bytes == 0) {
+		/* Nothing worth publishing — discard the .tmp. */
 		close(fd);
+		if (path) {
+			char tmp_path[320];
+			snprintf(tmp_path, sizeof(tmp_path), "%s" RMR_TMP_SUFFIX, path);
+			unlink(tmp_path);
+		}
+		return;
+	}
+
+	/* Shrink the reservation to what was actually written, flush,
+	 * then publish under the final name. rename() is atomic; a
+	 * crash before it loses only the in-flight segment. */
+	if (ftruncate(fd, (off_t)bytes) != 0)
+		RSS_ERROR("failed to shrink segment to %llu bytes: %s", (unsigned long long)bytes,
+			  strerror(errno));
+	fsync(fd);
+	close(fd);
+
+	if (path) {
+		char tmp_path[320];
+		snprintf(tmp_path, sizeof(tmp_path), "%s" RMR_TMP_SUFFIX, path);
+		if (rename(tmp_path, path) != 0)
+			RSS_ERROR("failed to publish segment %s: %s", path, strerror(errno));
 	}
 }
 
@@ -159,21 +212,90 @@ static bool storage_try_create(rmr_storage_t *st)
 	return true;
 }
 
+/* YYYY-MM-DD only — deliberately not clips/, timelapse/, or anything
+ * user-created; each storage instance sweeps its own date dirs. */
+static bool is_date_dir(const char *name)
+{
+	if (strlen(name) != 10 || name[4] != '-' || name[7] != '-')
+		return false;
+	for (int i = 0; i < 10; i++) {
+		if (i == 4 || i == 7)
+			continue;
+		if (name[i] < '0' || name[i] > '9')
+			return false;
+	}
+	return true;
+}
+
+/*
+ * Remove .tmp leftovers from an unclean shutdown. rmr is the only
+ * writer and this runs before the first segment of the current run
+ * opens, so any .tmp found is garbage from a previous run.
+ */
+static void sweep_stale_tmp(rmr_storage_t *st)
+{
+	int removed = 0;
+
+	DIR *d = opendir(st->base_path);
+	if (!d)
+		return;
+
+	struct dirent *ent;
+	while ((ent = readdir(d)) != NULL) {
+		if (!is_date_dir(ent->d_name))
+			continue;
+
+		char day_dir[320];
+		snprintf(day_dir, sizeof(day_dir), "%s/%s", st->base_path, ent->d_name);
+
+		DIR *dd = opendir(day_dir);
+		if (!dd)
+			continue;
+		struct dirent *fe;
+		while ((fe = readdir(dd)) != NULL) {
+			size_t len = strlen(fe->d_name);
+			if (len < 5 + RMR_TMP_SUFFIX_LEN + 4)
+				continue; /* shorter than HH-MM-SS.mp4.tmp */
+			if (strcmp(fe->d_name + len - 4 - RMR_TMP_SUFFIX_LEN,
+				   ".mp4" RMR_TMP_SUFFIX) != 0)
+				continue;
+
+			char fpath[512];
+			snprintf(fpath, sizeof(fpath), "%s/%s", day_dir, fe->d_name);
+			if (unlink(fpath) == 0)
+				removed++;
+		}
+		closedir(dd);
+	}
+	closedir(d);
+
+	if (removed > 0)
+		RSS_INFO("removed %d partial recording(s) left by an unclean shutdown", removed);
+}
+
 bool rmr_storage_available(rmr_storage_t *st)
 {
 	if (!st)
 		return false;
-	if (access(st->base_path, W_OK) == 0)
-		return true;
-	if (storage_try_create(st))
-		return true;
 
-	int64_t now = rss_timestamp_us();
-	if (now - st->last_wait_warn_us >= 60000000LL) {
-		RSS_WARN("waiting for storage: %s", st->base_path);
-		st->last_wait_warn_us = now;
+	bool ok = access(st->base_path, W_OK) == 0 || storage_try_create(st);
+	if (!ok) {
+		int64_t now = rss_timestamp_us();
+		if (now - st->last_wait_warn_us >= 60000000LL) {
+			RSS_WARN("waiting for storage: %s", st->base_path);
+			st->last_wait_warn_us = now;
+		}
+		return false;
 	}
-	return false;
+
+	/* First time the media is seen this run: clear whatever an
+	 * unclean shutdown left behind. rmr is the only writer and no
+	 * segment is open yet, so no .tmp can be in flight. */
+	if (!st->swept) {
+		st->swept = true;
+		sweep_stale_tmp(st);
+	}
+	return true;
 }
 
 /* ── Storage cleanup ── */

--- a/rmr/rmr_storage.h
+++ b/rmr/rmr_storage.h
@@ -15,6 +15,7 @@ typedef struct {
 	int segment_minutes;   /* segment duration (default 5) */
 	int segment_seconds;   /* nonzero overrides minutes (debug/test) */
 	int max_storage_mb;    /* 0 = unlimited */
+	uint64_t prealloc_bytes; /* 0 = grow organically (no reservation) */
 } rmr_storage_config_t;
 
 /* Create/destroy storage manager */
@@ -22,11 +23,15 @@ rmr_storage_t *rmr_storage_create(const rmr_storage_config_t *cfg);
 void rmr_storage_destroy(rmr_storage_t *st);
 
 /* Open a new segment file. Creates date directory if needed.
- * Returns fd on success, -1 on error. Writes path to path_out. */
+ * Recording happens under <name>.mp4.tmp; the final name appears
+ * only at close. Returns fd on success, -1 on error. Writes the
+ * final path to path_out. */
 int rmr_storage_open_segment(rmr_storage_t *st, char *path_out, int path_out_size);
 
-/* Close a segment file. */
-void rmr_storage_close_segment(int fd);
+/* Close a segment file: shrink the reservation to `bytes` written,
+ * fsync, then publish under the final name by rename(). `bytes` == 0
+ * discards the file. */
+void rmr_storage_close_segment(int fd, const char *path, uint64_t bytes);
 
 /* Next wall-clock boundary at a multiple of the segment length,
  * strictly after now_rt_us. Pure -- times injected for testability. */

--- a/tests/test_storage.c
+++ b/tests/test_storage.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 static bool same_dev_as_root(const char *path)
@@ -161,6 +162,143 @@ TEST storage_refuses_rootfs_autocreate(void)
 	PASS();
 }
 
+TEST storage_publishes_final_name_on_close(void)
+{
+	char dir[] = "/tmp/rmr_storage_test_XXXXXX";
+	ASSERT(mkdtemp(dir));
+
+	rmr_storage_config_t cfg = {.base_path = dir, .segment_minutes = 5};
+	rmr_storage_t *st = rmr_storage_create(&cfg);
+	ASSERT(st);
+
+	char path[256];
+	int fd = rmr_storage_open_segment(st, path, sizeof(path));
+	ASSERT(fd >= 0);
+
+	char tmp[300];
+	snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+	ASSERT_EQ(4, (int)write(fd, "data", 4));
+
+	/* In flight: only the .tmp twin exists. */
+	ASSERT(access(tmp, F_OK) == 0);
+	ASSERT(access(path, F_OK) != 0);
+
+	rmr_storage_close_segment(fd, path, 4);
+
+	/* Published: .mp4 with exactly the bytes written. */
+	struct stat s;
+	ASSERT(stat(path, &s) == 0);
+	ASSERT_EQ(4, (int)s.st_size);
+	ASSERT(access(tmp, F_OK) != 0);
+
+	rmr_storage_destroy(st);
+	snprintf(tmp, sizeof(tmp), "%s", path);
+	*strrchr(tmp, '/') = '\0';
+	rmdir(tmp);
+	rmdir(dir);
+	PASS();
+}
+
+TEST storage_discards_empty_segment(void)
+{
+	char dir[] = "/tmp/rmr_storage_test_XXXXXX";
+	ASSERT(mkdtemp(dir));
+
+	rmr_storage_config_t cfg = {.base_path = dir, .segment_minutes = 5};
+	rmr_storage_t *st = rmr_storage_create(&cfg);
+	ASSERT(st);
+
+	char path[256];
+	int fd = rmr_storage_open_segment(st, path, sizeof(path));
+	ASSERT(fd >= 0);
+
+	char tmp[300];
+	snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+	ASSERT(access(tmp, F_OK) == 0);
+
+	rmr_storage_close_segment(fd, path, 0);
+
+	/* Nothing written: no .mp4, no .tmp. */
+	ASSERT(access(path, F_OK) != 0);
+	ASSERT(access(tmp, F_OK) != 0);
+
+	rmr_storage_destroy(st);
+	rmdir(dir);
+	PASS();
+}
+
+TEST storage_prealloc_shrinks_on_close(void)
+{
+	char dir[] = "/tmp/rmr_storage_test_XXXXXX";
+	ASSERT(mkdtemp(dir));
+
+	rmr_storage_config_t cfg = {.base_path = dir, .segment_minutes = 5, .prealloc_bytes = 4096};
+	rmr_storage_t *st = rmr_storage_create(&cfg);
+	ASSERT(st);
+
+	char path[256];
+	int fd = rmr_storage_open_segment(st, path, sizeof(path));
+	ASSERT(fd >= 0);
+
+	/* Reservation is live while recording (metadata-only growth). */
+	char tmp[300];
+	snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+	struct stat s;
+	ASSERT(stat(tmp, &s) == 0);
+	ASSERT_EQ(4096, (int)s.st_size);
+
+	ASSERT_EQ(7, (int)write(fd, "payload", 7));
+	rmr_storage_close_segment(fd, path, 7);
+
+	/* Shrunk to the written size at publication. */
+	ASSERT(stat(path, &s) == 0);
+	ASSERT_EQ(7, (int)s.st_size);
+
+	rmr_storage_destroy(st);
+	snprintf(tmp, sizeof(tmp), "%s", path);
+	*strrchr(tmp, '/') = '\0';
+	rmdir(tmp);
+	rmdir(dir);
+	PASS();
+}
+
+TEST storage_sweeps_stale_tmp_on_first_use(void)
+{
+	char dir[] = "/tmp/rmr_storage_test_XXXXXX";
+	ASSERT(mkdtemp(dir));
+
+	/* Simulate an unclean shutdown: a date dir with a leftover .tmp
+	 * plus a clean .mp4 that must survive. */
+	time_t now = time(NULL);
+	struct tm tm;
+	localtime_r(&now, &tm);
+	char day[320], good[512], stale[512];
+	snprintf(day, sizeof(day), "%s/%04d-%02d-%02d", dir, tm.tm_year + 1900, tm.tm_mon + 1,
+		 tm.tm_mday);
+	ASSERT(mkdir(day, 0755) == 0);
+	snprintf(good, sizeof(good), "%s/10-00-00.mp4", day);
+	snprintf(stale, sizeof(stale), "%s/11-00-00.mp4.tmp", day);
+	FILE *g = fopen(good, "w"), *s = fopen(stale, "w");
+	ASSERT(good != NULL && g != NULL);
+	ASSERT(stale != NULL && s != NULL);
+	fclose(g);
+	fclose(s);
+
+	rmr_storage_config_t cfg = {.base_path = dir, .segment_minutes = 5};
+	rmr_storage_t *st = rmr_storage_create(&cfg);
+	ASSERT(st);
+	ASSERT(rmr_storage_available(st)); /* triggers the sweep */
+
+	ASSERT(access(stale, F_OK) != 0); /* gone */
+	ASSERT(access(good, F_OK) == 0);  /* kept */
+
+	rmr_storage_destroy(st);
+	unlink(good);
+	rmdir(day);
+	rmdir(dir);
+	PASS();
+}
+
 SUITE(storage_suite)
 {
 	RUN_TEST(storage_boundary_from_mid_period);
@@ -172,4 +310,8 @@ SUITE(storage_suite)
 	RUN_TEST(storage_available_existing_dir);
 	RUN_TEST(storage_autocreate_on_mounted_fs);
 	RUN_TEST(storage_refuses_rootfs_autocreate);
+	RUN_TEST(storage_publishes_final_name_on_close);
+	RUN_TEST(storage_discards_empty_segment);
+	RUN_TEST(storage_prealloc_shrinks_on_close);
+	RUN_TEST(storage_sweeps_stale_tmp_on_first_use);
 }


### PR DESCRIPTION
## Problem

Continuous recording on vfat/exfat SD cards has two failure modes around power loss and card yank:

- The file grows organically, so the FAT chain is extended every few seconds. Each extension rewrites FAT sectors — shared metadata on the card — so a yank has a high probability of landing mid-FAT-rewrite, and a torn FAT sector can crosslink or destroy many unrelated files and directories at once, not just the recording in progress.
- A segment interrupted mid-write stays under its final `HH-MM-SS.mp4` name, so players and NVR importers trip over truncated files.

## Change

Recording now happens under a `<name>.mp4.tmp` twin for every sink rmr writes (segments, motion clips, timelapse):

- At open, an optional `recording.prealloc_mb` reservation grows the file to full segment size with `ftruncate` — never `fallocate`, which vfat rejects (EOPNOTSUPP) and exfat-nofuse does not implement. On both filesystems the truncate-growth path (`fat_cont_expand`) only writes metadata. With the reservation in place, the FAT chain is built once at open and freed once at close (plus the exfat allocation bitmap), so during the recording body only data clusters are written: the window where a yank can corrupt shared FAT metadata shrinks from continuously open to two brief bursts per segment. Reserved clusters are never touched, so a yanked card keeps its old contents intact.
- At close the file is shrunk to what was actually written, fsynced, and `rename()`d to the final `.mp4`. A crash can only ever lose the in-flight segment, never publish a truncated one.
- Empty segments (0 bytes) discard their `.tmp`.
- A stale `.tmp` sweep runs once at rmr start, clearing anything left behind by a power cut.

A failed reservation (card nearly full) only logs a warning and the segment grows organically as before. `prealloc_mb = 0` (the default) disables the reservation; the `.tmp` + rename publish path is unconditional.

## Testing

- Unit tests added in `tests/test_storage.c` (greatest): prealloc reservation, shrink-on-close, empty-segment discard, stale `.tmp` sweep. Not yet executed — this host could only run the format gate (`git clang-format` against the merge base: clean). The CI Tests workflow is manual dispatch; happy to run it if pointed at the branch.
- No device validation yet.



---

**Related Discord discussion:** https://discord.com/channels/1086012062649565286/1541413054145761322