### PR TITLE
ric: stabilize night detection and probe behavior

### DIFF
--- a/build-asan.sh
+++ b/build-asan.sh
@@ -343,7 +343,7 @@ echo "  -> rsd"
 echo "=== RIC ==="
 $CC $CFLAGS -c "$RAPTOR_DIR/ric/ric_main.c" -o "$OUT/ric_main.o"
 $CC $CFLAGS -c "$RAPTOR_DIR/ric/ric_json.c" -o "$OUT/ric_json.o"
-$CC $CFLAGS -c "$RAPTOR_DIR/ric/ric_daynight.c" -o "$OUT/ric_daynight.o"
+$CC $CFLAGS $HAL_CFLAGS -c "$RAPTOR_DIR/ric/ric_daynight.c" -o "$OUT/ric_daynight.o"
 $CC $CFLAGS -c "$RAPTOR_DIR/ric/ric_photo.c" -o "$OUT/ric_photo.o"
 $CC -o "$OUT/ric" "$OUT/ric_main.o" "$OUT/ric_json.o" "$OUT/ric_daynight.o" "$OUT/ric_photo.o" $LIBS $LDFLAGS
 echo "  -> ric"

--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -358,9 +358,10 @@ position = bottom_right
                               # luma probe (day detection for sensors whose
                               # gain floors under IR, e.g. T20; 0 = off)
 # probe_holdoff_sec = 60      # minimum seconds between failed probes
-# probe_recheck_sec = 600     # probe anyway after this long in night with
+# probe_recheck_sec = 0       # optionally probe after this long in night with
                               # no dip: strong close-range IR can hide room
-                              # light from every AE metric (0 = off)
+                              # light from every AE metric; this cuts IR and
+                              # visibly disturbs live video, so default is off
 # adc_channel = 0             # ADC channel for photoresistor (trigger=adc)
 # adc_night = 200             # ADC below this -> night (trigger=adc)
 # adc_day = 600               # ADC above this -> day (trigger=adc)

--- a/ric/ric.h
+++ b/ric/ric.h
@@ -150,7 +150,7 @@ typedef struct {
 	int probe_holdoff_sec; /* minimum spacing between failed probes (default 60) */
 	int probe_recheck_sec; /* probe anyway after this long in night with no dip:
 				* IR wash can hide ambient light from every AE
-				* metric (default 600, 0 = off) */
+				* metric (default 0/off; probing disturbs video) */
 
 	/* Gain trigger thresholds (legacy, trigger=gain only) */
 	int night_threshold; /* gain above this → night */
@@ -220,10 +220,11 @@ typedef struct {
 
 	/* Baseline settling: gc2053-class AE walks for many seconds after
 	 * the IR lights the scene; the cooldown extends until three
-	 * consecutive polls agree within 10% (walks step and can hold a
-	 * value briefly), within a hard cap, so the baseline reflects a
-	 * settled reading instead of a mid-walk value. */
+	 * consecutive gain and EV polls agree within 2%, within a hard cap,
+	 * so the baseline reflects a settled reading instead of a mid-walk
+	 * value. */
 	uint32_t settle_prev_gain;
+	uint32_t settle_prev_ev;
 	int settle_agree_run;
 	int settle_extend_left;
 

--- a/ric/ric.h
+++ b/ric/ric.h
@@ -181,6 +181,7 @@ typedef struct {
 
 	/* Dual-GPIO IR-cut coil pulse width */
 	int pulse_ms;
+	bool pulse_ms_explicit; /* raptor.conf overrides device metadata */
 } ric_config_t;
 
 /* Global state */

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -24,6 +24,13 @@
  * LEDs, before the luma reading is believed. */
 #define RIC_PROBE_SETTLE_POLLS 3
 
+/* A slow AE walk changes less than 10% per poll and fooled the old
+ * pairwise test into accepting a transition as a night baseline. Two
+ * percent still tolerates normal quantization/noise while rejecting the
+ * measured post-IR walk. */
+#define RIC_BASELINE_SETTLE_PCT		 2
+#define RIC_BASELINE_SETTLE_EXTEND_POLLS 17
+
 /* ── ADC via kernel device nodes ── */
 
 /* jz_adc_aux ioctl contract: cmd 0 enables the channel, cmd 1
@@ -398,6 +405,26 @@ void ric_force_mode(ric_state_t *st, ric_mode_t mode)
 	ric_set_mode(st, mode);
 }
 
+static void ric_baseline_settle_begin(ric_state_t *st)
+{
+	st->settle_prev_gain = 0;
+	st->settle_prev_ev = 0;
+	st->settle_agree_run = 0;
+	st->settle_extend_left = RIC_BASELINE_SETTLE_EXTEND_POLLS;
+}
+
+static bool ric_baseline_value_within(uint32_t previous, uint32_t current)
+{
+	if (previous == 0 || current == 0)
+		return false;
+
+	uint32_t difference = previous > current ? previous - current : current - previous;
+	uint32_t tolerance = (uint32_t)((uint64_t)previous * RIC_BASELINE_SETTLE_PCT / 100);
+	if (tolerance == 0)
+		tolerance = 1;
+	return difference <= tolerance;
+}
+
 /*
  * Re-arm the trigger machinery for a live trigger switch: every counter,
  * baseline and probe in flight describes the OLD trigger's view of the
@@ -417,9 +444,7 @@ void ric_trigger_rearm(ric_state_t *st)
 	st->day_count = 0;
 	st->night_count = 0;
 	st->cooldown_remaining = 3;
-	st->settle_prev_gain = 0;
-	st->settle_agree_run = 0;
-	st->settle_extend_left = 17;
+	ric_baseline_settle_begin(st);
 	st->night_gain_baseline = 0;
 	st->night_ev_baseline = 0;
 	st->night_detect_gain = 0;
@@ -459,9 +484,7 @@ void ric_set_mode(ric_state_t *st, ric_mode_t mode)
 	 * sampling itself extends while AE is still walking (see the
 	 * cooldown block in ric_poll_exposure). */
 	st->cooldown_remaining = 3;
-	st->settle_prev_gain = 0;
-	st->settle_agree_run = 0;
-	st->settle_extend_left = 17;
+	ric_baseline_settle_begin(st);
 	st->probe_recheck_polls = 0; /* re-armed when the baseline lands */
 	if (mode == RIC_MODE_DAY)
 		st->night_gain_baseline = 0;
@@ -625,19 +648,22 @@ void ric_poll_exposure(ric_state_t *st)
 			 * settled gain then read as a permanent probe dip and the
 			 * IR blinked at every holdoff). AE walks step and can
 			 * hold a value briefly, so one quiet pair is not settled:
-			 * adopt only after three consecutive polls agree within
-			 * 10%, and give up at a hard cap rather than wait
+			 * adopt only after three consecutive gain and EV polls agree
+			 * within 2%, and give up at a hard cap rather than wait
 			 * forever. */
-			bool within =
-				st->settle_prev_gain > 0 && total_gain > 0 &&
-				total_gain <= st->settle_prev_gain + st->settle_prev_gain / 10 &&
-				total_gain >= st->settle_prev_gain - st->settle_prev_gain / 10;
+			bool gain_within = !have_gain || ric_baseline_value_within(
+								 st->settle_prev_gain, total_gain);
+			bool ev_within =
+				!have_ev || ric_baseline_value_within(st->settle_prev_ev, ev);
+			bool within = (have_gain || have_ev) && gain_within && ev_within;
 			st->settle_agree_run = within ? st->settle_agree_run + 1 : 0;
-			/* No gain reported (ADC-only platforms) = nothing to
-			 * settle: adopt immediately, the baseline stays absent. */
-			if (have_gain && st->settle_agree_run < 2 && st->settle_extend_left > 0) {
+			/* Settle every metric used by the dip detector. A platform
+			 * reporting neither has no baseline to qualify. */
+			if ((have_gain || have_ev) && st->settle_agree_run < 2 &&
+			    st->settle_extend_left > 0) {
 				st->settle_extend_left--;
 				st->settle_prev_gain = total_gain;
+				st->settle_prev_ev = ev;
 				st->cooldown_remaining = 1;
 				return;
 			}
@@ -664,6 +690,7 @@ void ric_poll_exposure(ric_state_t *st)
 		/* Every cooldown poll seeds the settling comparison above,
 		 * so the first evaluation has a real predecessor. */
 		st->settle_prev_gain = total_gain;
+		st->settle_prev_ev = ev;
 		return;
 	}
 
@@ -821,6 +848,7 @@ void ric_poll_exposure(ric_state_t *st)
 					/* Cooldown resamples the baseline once the
 					 * restored IR settles. */
 					st->cooldown_remaining = 3;
+					ric_baseline_settle_begin(st);
 					RSS_INFO("probe found darkness; IR restored, next "
 						 "probe in %ds",
 						 st->settings.probe_holdoff_sec);

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -589,12 +589,11 @@ void ric_poll_exposure(ric_state_t *st)
 	 * missing exposure data -- it is the very fallback recommended
 	 * below for platforms without a readback.
 	 */
-	bool have_gain = has_valid_mask ?
-		(valid_mask & RSS_EXPOSURE_VALID_TOTAL_GAIN) != 0 : total_gain > 0;
-	bool have_luma = has_valid_mask ?
-		(valid_mask & RSS_EXPOSURE_VALID_AE_LUMA) != 0 : ae_luma > 0;
-	bool have_ev = has_valid_mask ?
-		(valid_mask & RSS_EXPOSURE_VALID_EV) != 0 : ev > 0;
+	bool have_gain =
+		has_valid_mask ? (valid_mask & RSS_EXPOSURE_VALID_TOTAL_GAIN) != 0 : total_gain > 0;
+	bool have_luma =
+		has_valid_mask ? (valid_mask & RSS_EXPOSURE_VALID_AE_LUMA) != 0 : ae_luma > 0;
+	bool have_ev = has_valid_mask ? (valid_mask & RSS_EXPOSURE_VALID_EV) != 0 : ev > 0;
 
 	if (st->settings.trigger != RIC_TRIGGER_ADC && !have_gain && !have_luma && !have_ev) {
 		if (!st->no_exposure_warned) {

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -13,6 +13,8 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 
+#include <raptor_hal.h>
+
 #include "ric.h"
 
 /* Backoff for day attempts after a failed verification, in polls
@@ -557,6 +559,8 @@ void ric_poll_exposure(ric_state_t *st)
 
 	uint32_t total_gain = 0, ae_luma = 0;
 	uint32_t ev = 0;
+	uint32_t valid_mask = 0;
+	bool has_valid_mask = false;
 	uint16_t wb_rgain = 0, wb_bgain = 0;
 	cJSON *parsed = cJSON_Parse(resp);
 	if (!parsed) {
@@ -566,27 +570,35 @@ void ric_poll_exposure(ric_state_t *st)
 	total_gain = json_get_uint(parsed, "total_gain");
 	ae_luma = json_get_uint(parsed, "ae_luma");
 	ev = json_get_uint(parsed, "ev");
+	const cJSON *valid_item = cJSON_GetObjectItem(parsed, "valid_mask");
+	if (cJSON_IsNumber(valid_item)) {
+		valid_mask = (uint32_t)valid_item->valuedouble;
+		has_valid_mask = true;
+	}
 	wb_rgain = (uint16_t)json_get_uint(parsed, "wb_rgain");
 	wb_bgain = (uint16_t)json_get_uint(parsed, "wb_bgain");
 	cJSON_Delete(parsed);
 
 	/*
-	 * Zero means "this backend cannot answer for that field" -- the
-	 * exposure contract raptor-hal documents in hal_isp.c, not a
-	 * convention invented here. A live sensor never reports a mean luma
-	 * of exactly 0, so treating it as absent costs nothing real.
+	 * New HALs report field validity explicitly, because zero can be a real
+	 * reading (notably ae_luma on the first black frame of a cold T31 ISP).
+	 * Keep the old nonzero sentinel behavior for an rvd that predates the
+	 * validity mask so independently upgraded daemons remain compatible.
 	 *
 	 * The ADC trigger reads its own sensor and must not be starved by
 	 * missing exposure data -- it is the very fallback recommended
 	 * below for platforms without a readback.
 	 */
-	bool have_gain = total_gain > 0;
-	bool have_luma = ae_luma > 0;
-	bool have_ev = ev > 0;
+	bool have_gain = has_valid_mask ?
+		(valid_mask & RSS_EXPOSURE_VALID_TOTAL_GAIN) != 0 : total_gain > 0;
+	bool have_luma = has_valid_mask ?
+		(valid_mask & RSS_EXPOSURE_VALID_AE_LUMA) != 0 : ae_luma > 0;
+	bool have_ev = has_valid_mask ?
+		(valid_mask & RSS_EXPOSURE_VALID_EV) != 0 : ev > 0;
 
 	if (st->settings.trigger != RIC_TRIGGER_ADC && !have_gain && !have_luma && !have_ev) {
 		if (!st->no_exposure_warned) {
-			RSS_WARN("no exposure data from rvd (gain, luma and ev all zero) -- "
+			RSS_WARN("no valid gain, luma or ev data from rvd -- "
 				 "holding %s mode. This platform's HAL has no exposure "
 				 "readback; use `raptorctl ric mode day|night`, or "
 				 "trigger=adc if the board has a photoresistor",

--- a/ric/ric_json.c
+++ b/ric/ric_json.c
@@ -235,8 +235,7 @@ static void gpio_led_pin(const cJSON *gpio, const char *key, int *pin, bool *act
 
 void ric_json_gpio_load(ric_config_t *c, const char *path)
 {
-	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0 &&
-	    c->pulse_ms_explicit)
+	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0 && c->pulse_ms_explicit)
 		return;
 
 	FILE *f = fopen(path, "r");
@@ -352,10 +351,8 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 
 	if (c->gpio_ircut >= 0 || c->gpio_irled >= 0)
 		RSS_INFO("GPIOs from %s: ircut=%d ircut2=%d irled=%d irled2=%d pulse=%dms%s%s%s",
-			 path,
-			 c->gpio_ircut, c->gpio_ircut2, c->gpio_irled, c->gpio_irled2,
-			 c->pulse_ms,
-			 c->ircut_active_low ? " ircut-active-low" : "",
+			 path, c->gpio_ircut, c->gpio_ircut2, c->gpio_irled, c->gpio_irled2,
+			 c->pulse_ms, c->ircut_active_low ? " ircut-active-low" : "",
 			 c->irled_active_low ? " irled-active-low" : "",
 			 c->irled2_active_low ? " irled2-active-low" : "");
 }

--- a/ric/ric_json.c
+++ b/ric/ric_json.c
@@ -11,6 +11,9 @@
  *                                (single inverted pin; the object is
  *                                 the standard's only polarity escape
  *                                 hatch, valid for the LED keys too)
+ *   "ircut": {"pin": [52, 53], "delay_us": 100000}
+ *                                (dual-coil pair with its hardware
+ *                                 pulse width; first = day, second = night)
  *   "ir850": 8 / "ir940": 9      (IR LED GPIOs)
  *   -1 or ""                     (explicitly disabled, silent)
  * "ircut": 999 means the board's filter hangs off the tmi8152
@@ -129,6 +132,85 @@ bad:
 	return false;
 }
 
+/* A structured dual-coil description uses one or two bare GPIO
+ * numbers. Per-pin polarity is expressed by pair order for pulse-mode
+ * filters; accepting nested active_low objects here would pretend ric
+ * implements a drive convention it does not. */
+static bool gpio_pin_array(const cJSON *item, int *pin, int *pin2)
+{
+	int n = cJSON_GetArraySize(item);
+	if (n < 1 || n > 2)
+		goto bad;
+	const cJSON *p = cJSON_GetArrayItem(item, 0);
+	if (!cJSON_IsNumber(p) || !valid_gpio(p->valueint))
+		goto bad;
+	*pin = p->valueint;
+	if (n == 2) {
+		p = cJSON_GetArrayItem(item, 1);
+		if (!cJSON_IsNumber(p) || !valid_gpio(p->valueint))
+			goto bad;
+		*pin2 = p->valueint;
+	}
+	return true;
+bad:
+	*pin = -1;
+	*pin2 = -1;
+	RSS_WARN("gpio.ircut.pin array must contain one or two GPIO numbers -- ignored");
+	return false;
+}
+
+/* Parse the structured IR-cut form shared with Thingino's generic
+ * ircut utility. RIC currently implements pulse drive; rejecting any
+ * other named mode is safer than silently applying pulse semantics to
+ * level-sequence hardware. */
+static bool ircut_object_mode_supported(const cJSON *item)
+{
+	const cJSON *mode = cJSON_GetObjectItemCaseSensitive(item, "mode");
+	if (mode && (!cJSON_IsString(mode) || !mode->valuestring ||
+		     strcmp(mode->valuestring, "pulse") != 0)) {
+		RSS_WARN("gpio.ircut mode is not pulse -- unsupported by ric");
+		return false;
+	}
+	return true;
+}
+
+static bool ircut_object(const cJSON *item, int *pin, int *pin2, bool *active_low)
+{
+	const cJSON *p = cJSON_GetObjectItemCaseSensitive(item, "pin");
+	if (cJSON_IsNumber(p)) {
+		if (!valid_gpio(p->valueint))
+			goto bad;
+		*pin = p->valueint;
+		*active_low = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(item, "active_low"));
+		return true;
+	}
+	if (cJSON_IsString(p) && p->valuestring)
+		return gpio_pin_pair(p->valuestring, "ircut.pin", pin, pin2);
+	if (cJSON_IsArray(p))
+		return gpio_pin_array(p, pin, pin2);
+bad:
+	RSS_WARN("gpio.ircut object carries no usable \"pin\" -- ignored");
+	return false;
+}
+
+/* thingino.json records actuator timing in microseconds because the
+ * shell GPIO utility uses usleep. RIC's public setting is milliseconds;
+ * round upward so conversion can never shorten a hardware pulse. */
+static void ircut_object_timing(const cJSON *item, ric_config_t *c)
+{
+	if (c->pulse_ms_explicit)
+		return;
+	const cJSON *delay = cJSON_GetObjectItemCaseSensitive(item, "delay_us");
+	if (!delay)
+		return;
+	if (!cJSON_IsNumber(delay) || delay->valuedouble < 1 || delay->valuedouble > 1000000) {
+		RSS_WARN("gpio.ircut delay_us must be in 1..1000000 -- using %dms", c->pulse_ms);
+		return;
+	}
+	int delay_us = delay->valueint;
+	c->pulse_ms = (delay_us + 999) / 1000;
+}
+
 /* ir850/ir940: a bare number or the {pin, active_low} object. */
 static void gpio_led_pin(const cJSON *gpio, const char *key, int *pin, bool *active_low)
 {
@@ -153,7 +235,8 @@ static void gpio_led_pin(const cJSON *gpio, const char *key, int *pin, bool *act
 
 void ric_json_gpio_load(ric_config_t *c, const char *path)
 {
-	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0)
+	if (c->gpio_ircut >= 0 && c->gpio_irled >= 0 && c->gpio_irled2 >= 0 &&
+	    c->pulse_ms_explicit)
 		return;
 
 	FILE *f = fopen(path, "r");
@@ -226,8 +309,12 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 		return;
 	}
 
+	cJSON *ircut = cJSON_GetObjectItemCaseSensitive(gpio, "ircut");
+	bool ircut_object_ok = !cJSON_IsObject(ircut) || ircut_object_mode_supported(ircut);
+	if (cJSON_IsObject(ircut) && ircut_object_ok)
+		ircut_object_timing(ircut, c);
+
 	if (c->gpio_ircut < 0) {
-		cJSON *ircut = cJSON_GetObjectItemCaseSensitive(gpio, "ircut");
 		int pin = -1, pin2 = -1;
 		bool alow = false;
 		if (cJSON_IsNumber(ircut)) {
@@ -240,8 +327,8 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 			else if (ircut->valueint > GPIO_PIN_MAX)
 				RSS_WARN("gpio.ircut %d is out of range -- ignored",
 					 ircut->valueint);
-		} else if (cJSON_IsObject(ircut)) {
-			gpio_object(ircut, "ircut", &pin, &alow);
+		} else if (cJSON_IsObject(ircut) && ircut_object_ok) {
+			ircut_object(ircut, &pin, &pin2, &alow);
 		} else if (cJSON_IsString(ircut) && ircut->valuestring) {
 			gpio_pin_pair(ircut->valuestring, "ircut", &pin, &pin2);
 		}
@@ -264,8 +351,10 @@ void ric_json_gpio_load(ric_config_t *c, const char *path)
 	cJSON_Delete(root);
 
 	if (c->gpio_ircut >= 0 || c->gpio_irled >= 0)
-		RSS_INFO("GPIOs from %s: ircut=%d ircut2=%d irled=%d irled2=%d%s%s%s", path,
+		RSS_INFO("GPIOs from %s: ircut=%d ircut2=%d irled=%d irled2=%d pulse=%dms%s%s%s",
+			 path,
 			 c->gpio_ircut, c->gpio_ircut2, c->gpio_irled, c->gpio_irled2,
+			 c->pulse_ms,
 			 c->ircut_active_low ? " ircut-active-low" : "",
 			 c->irled_active_low ? " irled-active-low" : "",
 			 c->irled2_active_low ? " irled2-active-low" : "");

--- a/ric/ric_json.h
+++ b/ric/ric_json.h
@@ -7,9 +7,9 @@
 #include "ric.h"
 
 /*
- * Fill any still-unset (-1) IR-cut / IR LED pins in c from the JSON
- * device description at path. A missing file is silent; a file that
- * exists but cannot be used warns.
+ * Fill any still-unset (-1) IR-cut / IR LED pins and non-explicit
+ * actuator timing in c from the JSON device description at path. A
+ * missing file is silent; a file that exists but cannot be used warns.
  */
 void ric_json_gpio_load(ric_config_t *c, const char *path);
 

--- a/ric/ric_main.c
+++ b/ric/ric_main.c
@@ -96,7 +96,7 @@ static void load_config(ric_state_t *st)
 			  rss_config_get_int(cfg, "ircut", "probe_holdoff_sec", 60), 1, 86400);
 	c->probe_recheck_sec =
 		cfg_clamp("probe_recheck_sec",
-			  rss_config_get_int(cfg, "ircut", "probe_recheck_sec", 600), 0, 86400);
+			  rss_config_get_int(cfg, "ircut", "probe_recheck_sec", 0), 0, 86400);
 
 	/* ADC thresholds (trigger=adc) */
 	c->adc_channel = rss_config_get_int(cfg, "ircut", "adc_channel", 0);

--- a/ric/ric_main.c
+++ b/ric/ric_main.c
@@ -132,11 +132,13 @@ static void load_config(ric_state_t *st)
 		"poll_interval_ms",
 		rss_config_get_int(cfg, "ircut", "poll_interval_ms", default_poll), 50, 10000);
 
-	/* Dual-GPIO coil pulse. 10ms is what the thingino ircut script has
-	 * driven the whole fleet with since thingino-daynight existed; both
-	 * 10ms and 100ms measured 20/20 reliable on a dual-GPIO Wyze Cam3,
-	 * so the default follows the fleet. Clamped: a zero pulse moves no
-	 * filter, and holding the coil for seconds is a heater. */
+	/* Probe before the getter stores its default. An explicit runtime
+	 * setting is policy and wins over timing in thingino.json; otherwise
+	 * the device description may replace the fleet's 10ms default with
+	 * the actuator's measured pulse width. */
+	c->pulse_ms_explicit = rss_config_get_str(cfg, "ircut", "pulse_ms", NULL) != NULL;
+	/* A zero pulse moves no filter, and holding the coil for seconds is
+	 * a heater. */
 	c->pulse_ms =
 		cfg_clamp("pulse_ms", rss_config_get_int(cfg, "ircut", "pulse_ms", 10), 1, 1000);
 

--- a/rvd/rvd_ctrl.c
+++ b/rvd/rvd_ctrl.c
@@ -1263,6 +1263,7 @@ static int handle_isp_cmd(const char *cmd, const char *cmd_json, rvd_state_t *st
 		rss_exposure_t exp = {0};
 		RSS_HAL_CALL(st->ops, isp_get_exposure, st->hal_ctx, &exp);
 		cJSON *r = cJSON_CreateObject();
+		cJSON_AddNumberToObject(r, "valid_mask", (double)exp.valid_mask);
 		cJSON_AddNumberToObject(r, "total_gain", (double)exp.total_gain);
 		cJSON_AddNumberToObject(r, "exposure_us", (double)exp.exposure_time);
 		cJSON_AddNumberToObject(r, "ae_luma", (double)exp.ae_luma);

--- a/tests/mock_hal.c
+++ b/tests/mock_hal.c
@@ -560,6 +560,9 @@ static int mock_get_exposure(void *ctx, rss_exposure_t *exp)
 	exp->ev = 50000;
 	exp->wb_rgain = 256;
 	exp->wb_bgain = 192;
+	exp->valid_mask = RSS_EXPOSURE_VALID_TOTAL_GAIN | RSS_EXPOSURE_VALID_TIME |
+			  RSS_EXPOSURE_VALID_AE_LUMA | RSS_EXPOSURE_VALID_EV |
+			  RSS_EXPOSURE_VALID_WB_RGAIN | RSS_EXPOSURE_VALID_WB_BGAIN;
 	return RSS_OK;
 }
 

--- a/tests/ric_harness.py
+++ b/tests/ric_harness.py
@@ -43,6 +43,7 @@ WORK = os.environ.get("RIC_TEST_WORK", "/tmp/ric-test")
 RIC_BIN = os.environ.get("RIC_BIN", "asan-out/ric")
 ADC_PRELOAD = os.environ.get("RIC_ADC_PRELOAD", "")
 POLL_MS = 200
+EXPOSURE_VALID_AE_LUMA = 1 << 2
 
 PASS = 0
 FAIL = 0
@@ -212,6 +213,8 @@ class StubRvd:
                         "wb_rgain": sc.get("rgain", 0),
                         "wb_bgain": sc.get("bgain", 0),
                     }
+                    if "valid_mask" in sc:
+                        resp["valid_mask"] = sc["valid_mask"]
                 elif cmd == "set-running-mode":
                     val = json.loads(req).get("value", "?")
                     with self.lock:
@@ -1047,6 +1050,25 @@ def scenario_zero_exposure(stub, watch):
     ok = r is not None and r.get("state") == "night"
     ev_ok = wait_for(lambda: last_value(watch.since(gm), IRLED) == "1", 3)
     result(ok and ev_ok, "zero exposure: manual override still actuates", str(r))
+    ric.stop()
+
+
+def scenario_valid_zero_luma(stub, watch):
+    """An explicitly valid zero luma is a black frame, not missing data.
+    This is the first exposure sample on a cold T31 ISP."""
+    stub.set_scene(luma=0, gain=0, ev=0,
+                   valid_mask=EXPOSURE_VALID_AE_LUMA)
+    ric = Ric("valid-zero-luma", LUMA_CONF)
+    if not ric.wait_running():
+        result(False, "valid-zero-luma: ric start", "no 'ric running'")
+        ric.stop()
+        return
+    mm = stub.mark()
+    ok = wait_for(lambda: "night" in stub.modes_since(mm), 4)
+    result(ok, "valid zero luma drives night",
+           str(stub.modes_since(mm)))
+    result("no valid gain, luma or ev" not in ric.read_log(),
+           "valid zero luma is not reported missing", ric.read_log()[-300:])
     ric.stop()
 
 
@@ -2478,6 +2500,7 @@ def main():
         scenario_photo_interference,
         scenario_photo_no_ev,
         scenario_zero_exposure,
+        scenario_valid_zero_luma,
         scenario_partial_fields,
         scenario_adc,
         scenario_adc_dead,

--- a/tests/ric_harness.py
+++ b/tests/ric_harness.py
@@ -781,6 +781,60 @@ def scenario_probe_slow_ae(stub, watch):
     ric.stop()
 
 
+def scenario_probe_restore_slow_ae(stub, watch):
+    """A failed ambient probe must restart baseline settling when IR
+    returns. The post-IR AE walk is deliberately smooth: every old
+    pairwise sample differs by no more than 10%, so stale settle state
+    accepted a transitional EV and re-probed after every holdoff."""
+    conf = LUMA_CONF + "probe_holdoff_sec = 1\n"
+    stub.set_scene(luma=70, gain=4500, ev=1200000)
+    ric = Ric("proberestorewalk", conf)
+    if not ric.wait_running():
+        result(False, "probe restore walk: ric start", "no 'ric running'")
+        ric.stop()
+        return
+    time.sleep(0.5)
+
+    mm = stub.mark()
+    stub.set_scene(luma=6, gain=8192, ev=50000000)
+    if not wait_for(lambda: "night" in stub.modes_since(mm), 4):
+        result(False, "probe restore walk: night entry", str(stub.modes_since(mm)))
+        ric.stop()
+        return
+    stub.set_scene(luma=72, gain=20000, ev=200000)
+    time.sleep(8 * POLL_MS / 1000.0)
+
+    gm = watch.mark()
+    stub.set_scene(luma=72, gain=14000, ev=140000)
+    if not wait_for(lambda: last_value(watch.since(gm), IRLED) == "0", 4):
+        result(False, "probe restore walk: dip lifts IR", str(watch.since(gm)))
+        ric.stop()
+        return
+
+    rm = watch.mark()
+    stub.set_scene(luma=4, gain=90000, ev=900000)
+    if not wait_for(lambda: last_value(watch.since(rm), IRLED) == "1", 4):
+        result(False, "probe restore walk: darkness restores IR", str(watch.since(rm)))
+        ric.stop()
+        return
+
+    walk = []
+    for gain in (30000, 27000, 24300, 21870, 19683, 17714, 15943, 14348,
+                 13000, 13000, 13000, 13000):
+        walk.append({"luma": 72, "gain": gain, "ev": gain * 10})
+    stub.set_scene_sequence(walk)
+    time.sleep((len(walk) + 10) * POLL_MS / 1000.0)
+
+    led_vals = [c for _, p, _, c in watch.since(rm) if p == IRLED]
+    result("0" not in led_vals,
+           "probe restore walk: settled return does not re-probe",
+           str(watch.since(rm)) + " " + ric.read_log()[-300:])
+    st = ric_status()
+    result(st is not None and st.get("state") == "night",
+           "probe restore walk: remains in night", str(st))
+    ric.stop()
+
+
 def scenario_probe_recheck(stub, watch):
     """IR wash can hide ambient light entirely: on a Wyze V3 the IR-lit
     scene reads EV 637 lit vs ~700 dark -- a 9% perturbation no dip
@@ -932,6 +986,12 @@ def scenario_ctrl(stub, watch):
         s is not None and s.get("status") == "ok" and "exposure" in s,
         "ctrl: status carries exposure block",
         str(s),
+    )
+    thresholds = ctrl_cmd(RUN_DIR + "/ric.sock", {"cmd": "get-thresholds"})
+    result(
+        thresholds is not None and thresholds.get("probe_recheck_sec") == 0,
+        "ctrl: disruptive interval probe defaults off",
+        str(thresholds),
     )
     ric.stop()
 
@@ -2399,6 +2459,7 @@ def main():
         scenario_probe_dark_restore,
         scenario_noir_luma_dawn,
         scenario_probe_slow_ae,
+        scenario_probe_restore_slow_ae,
         scenario_probe_recheck,
         scenario_recheck_rearm,
         scenario_ctrl,

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -364,6 +364,7 @@ check_contains "enc-get color2grey" "color2grey" "$OUT/raptorctl" rvd enc-get 0 
 check_contains "get-isp" "brightness" "$OUT/raptorctl" rvd get-isp
 check_contains "get-wb" "mode" "$OUT/raptorctl" rvd get-wb
 check_contains "get-exposure" "total_gain" "$OUT/raptorctl" rvd get-exposure
+check_contains "get-exposure validity" "valid_mask" "$OUT/raptorctl" rvd get-exposure
 check_contains "set-brightness" "ok" "$OUT/raptorctl" rvd set-brightness 200
 
 # Config

--- a/tests/test_ric_json.c
+++ b/tests/test_ric_json.c
@@ -34,6 +34,7 @@ static ric_config_t fresh_config(void)
 	c.gpio_ircut2 = -1;
 	c.gpio_irled = -1;
 	c.gpio_irled2 = -1;
+	c.pulse_ms = 10;
 	return c;
 }
 
@@ -90,6 +91,46 @@ TEST ric_json_object_pins(void)
 	ASSERT(c.irled_active_low);
 	ASSERT_EQ(50, c.gpio_irled2);
 	ASSERT_FALSE(c.irled2_active_low);
+	unlink(FIXTURE);
+	PASS();
+}
+
+TEST ric_json_object_pair_and_timing(void)
+{
+	ric_config_t c = fresh_config();
+	const char *j = "{\"gpio\":{\"ircut\":{\"pin\":[52,53],\"delay_us\":100000}}}";
+	write_fixture(j, strlen(j));
+	ric_json_gpio_load(&c, FIXTURE);
+	ASSERT_EQ(52, c.gpio_ircut);
+	ASSERT_EQ(53, c.gpio_ircut2);
+	ASSERT_EQ(100, c.pulse_ms);
+	unlink(FIXTURE);
+	PASS();
+}
+
+TEST ric_json_explicit_timing_wins(void)
+{
+	ric_config_t c = fresh_config();
+	c.pulse_ms = 75;
+	c.pulse_ms_explicit = true;
+	const char *j = "{\"gpio\":{\"ircut\":{\"pin\":[52,53],\"delay_us\":100000}}}";
+	write_fixture(j, strlen(j));
+	ric_json_gpio_load(&c, FIXTURE);
+	ASSERT_EQ(52, c.gpio_ircut);
+	ASSERT_EQ(53, c.gpio_ircut2);
+	ASSERT_EQ(75, c.pulse_ms);
+	unlink(FIXTURE);
+	PASS();
+}
+
+TEST ric_json_unsupported_drive_mode_rejected(void)
+{
+	ric_config_t c = fresh_config();
+	const char *j = "{\"gpio\":{\"ircut\":{\"pin\":[52,53],\"mode\":\"level-sequence\"}}}";
+	write_fixture(j, strlen(j));
+	ric_json_gpio_load(&c, FIXTURE);
+	ASSERT_EQ(-1, c.gpio_ircut);
+	ASSERT_EQ(-1, c.gpio_ircut2);
 	unlink(FIXTURE);
 	PASS();
 }
@@ -364,6 +405,9 @@ SUITE(ric_json_suite)
 	RUN_TEST(ric_json_int_pins);
 	RUN_TEST(ric_json_dual_string_ircut);
 	RUN_TEST(ric_json_object_pins);
+	RUN_TEST(ric_json_object_pair_and_timing);
+	RUN_TEST(ric_json_explicit_timing_wins);
+	RUN_TEST(ric_json_unsupported_drive_mode_rejected);
 	RUN_TEST(ric_json_object_extra_keys_ignored);
 	RUN_TEST(ric_json_object_without_pin_rejected);
 	RUN_TEST(ric_json_plain_form_resets_polarity);


### PR DESCRIPTION
Fix two independent night-mode delays observed on a Wyze VDB2/T31X.

* Restart gain and EV baseline settling after a failed ambient probe, require both metrics to stabilize within 2%, and make unconditional interval probes opt-in. This removed the recurring 11-second IR-off disturbance; a 200-second soak held encoded YAVG within a 0.33-level span.
* Consume the exposure validity mask added by gtxaspec/raptor-hal#9. A cold T31 legitimately returns `ae_luma=0`; treating zero as unavailable delayed night detection from the configured 5 seconds to roughly 83 seconds. Legacy RVD responses without the mask retain their old nonzero-sentinel behavior.

The cold-device test with both changes staged switched NIGHT 7 seconds after RVD start and kept `hflip`/`vflip` plus native 2048x1536 RTSP intact. Includes zero-luma and legacy-response regression coverage.

Depends on gtxaspec/raptor-hal#9.

Signed-off-by: Matt Davis <matteius@gmail.com>