### PR TITLE
rvd: stop sizing every ring for an all-intra stream

### DIFF
--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -1519,10 +1519,25 @@ create_ring:
 				uint32_t fps = s->enc_cfg.fps_num;
 				if (fps == 0)
 					fps = 25;
-				/* I-frame headroom: 4x for normal GOP, 8x for
-				 * short GOP where every frame is an I-frame */
+				/*
+				 * I-frame headroom. The data region has to hold
+				 * `slots` frames, and an I-frame is bigger than the
+				 * bitrate's per-frame average; 4x covers that.
+				 *
+				 * 8x is meant for an all-intra stream, where every
+				 * frame carries a whole picture. The test for that
+				 * used to be `gop <= fps`, which is true of the
+				 * default config rather than of an unusual one: gop
+				 * is normally unset and defaults to fps in
+				 * load_stream_config, and a one-second GOP is an
+				 * ordinary GOP. So every board took the 8x branch and
+				 * sized every ring at twice what it needed -- 3.2MB
+				 * instead of 1.6MB for a 3Mbps main stream, out of a
+				 * /dev/shm that on a 64MB board shares ~27MB with
+				 * everything else. Ask for what the branch says.
+				 */
 				uint32_t gop = s->enc_cfg.gop_length;
-				uint32_t iframe_mult = (gop > 0 && gop <= fps) ? 8 : 4;
+				uint32_t iframe_mult = (gop > 0 && gop <= 2) ? 8 : 4;
 				uint32_t max_frame =
 					(uint32_t)((uint64_t)bps * iframe_mult / 8 / fps);
 				if (max_frame < min_frame)


### PR DESCRIPTION
`rvd_stream_init` sizes a bitstream ring's data region from a worst-case frame,
and the multiplier that produces it has two branches: 4x for a normal GOP, 8x
for a short one "where every frame is an I-frame". The test picking between
them is `gop <= fps`.

That describes the default configuration rather than an unusual one. `gop` is
normally unset, and `load_stream_config` defaults it to `fps`, so the condition
is true on every board that has not deliberately set it — and a one-second GOP
is an ordinary GOP, not an all-intra stream. The 4x branch is unreachable, and
every ring on every platform is sized at twice what it needs.

That is 3.2 MB rather than 1.6 MB for a 3 Mbps main stream. Rings live in
/dev/shm, which is real RAM. On the 64 MB board I measured this on, the
bootloader leaves Linux 27632 KB for everything, and the doubled rings took
4.6 MB of it: the streams alone left ~3.4 MB available at idle, and rsd
invoking the OOM killer — which picked rvd — was reachable from there. Halving
them takes /dev/shm from 4.59 MB to 2.62 MB and idle availability from 3.4 MB
to 6.7 MB, with no config change.

**Buffering is unaffected.** The data region is a byte pool and a slot is a
descriptor, so retention is `min(slots, data/avg_frame)`; at 4x the pool still
backs `4*slots` average frames and the 32-slot window stays the binding limit.
No frames are lost on a stalled client.

The threshold is now `gop <= 2`, which is what the branch was describing:
`gop=1` is every frame an I-frame, `gop=2` is I,P,I,P. A board that really does
run all-intra still gets 8x.

Cut from `main`, one commit, one file. Host test suite: 327 pass, 0 fail.
`git-clang-format` against clang-format 19 is clean.
