### PR TITLE
rvd: require stream storage capability for refmode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,10 @@ endif
 
 # System libs for HAL-linked daemons
 # Shim must come BEFORE Ingenic SDK libs — symbols must be resolved first.
-LDFLAGS_HAL := $(LDFLAGS_SYSROOT) $(SHIM_LIB) -limp -lalog -lpthread -lrt -lm -ldl -latomic
+# LIB_IMP may name a link-only SDK ABI library while the target image ships
+# another compatible libimp implementation (for example OpenIMP).
+LIB_IMP ?= -limp
+LDFLAGS_HAL := $(LDFLAGS_SYSROOT) $(SHIM_LIB) $(LIB_IMP) -lalog -lpthread -lrt -lm -ldl -latomic
 
 # IVS detection libs
 ifeq ($(IVS_DETECT),1)

--- a/rvd/rvd.h
+++ b/rvd/rvd.h
@@ -38,6 +38,7 @@ typedef struct {
 	bool vbs_fallback_tried;    /* one-shot single-buffer fallback consumed */
 	int64_t started_us;	    /* last rvd_stream_start, for the fallback grace */
 	bool is_jpeg;		    /* true for snapshot channel */
+	bool refmode_eligible;	    /* finalized encoder output is externally referenceable */
 	bool jpeg_idle;		    /* true = stop encoder when no consumers */
 	int64_t pulse_next_us;	    /* jpeg_pulse: earliest next RecvPic start */
 	uintptr_t enc_buf_addrs[8]; /* refmode: unique virAddr bases seen */

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -120,7 +120,7 @@ static void rvd_stream_enable_refmode(rvd_state_t *st, int idx)
 {
 	rvd_stream_t *s = &st->streams[idx];
 
-	if (!s->ring || s->is_jpeg || s->enc_cfg.codec == RSS_CODEC_JPEG || !st->refmode)
+	if (!s->ring || s->is_jpeg || s->enc_cfg.codec == RSS_CODEC_JPEG || !s->refmode_eligible)
 		return;
 
 	if (st->refmode_shm && st->enc_shm_size[idx] > 0) {
@@ -1356,6 +1356,7 @@ int rvd_stream_init(rvd_state_t *st, int idx)
 	rvd_stream_t *s = &st->streams[idx];
 	rss_config_t *cfg = st->cfg;
 	int ret;
+	s->refmode_eligible = false;
 
 	if (st->hal_caps && !st->hal_caps->has_framesource) {
 		/* No graph to build: the backend's encoder slot owns the
@@ -1563,6 +1564,20 @@ int rvd_stream_init(rvd_state_t *st, int idx)
 		RSS_DEBUG("stream%d bind: %d stages", idx, chain_len);
 	}
 
+	if (!s->is_jpeg && s->enc_cfg.codec != RSS_CODEC_JPEG && st->refmode) {
+		if (st->refmode_shm) {
+			s->refmode_eligible = st->enc_shm_size[idx] > 0;
+		} else if (st->rmem_size > 0 && RSS_HAL_CALL(st->ops, enc_stream_is_rmem,
+							     st->hal_ctx, s->chn) == RSS_OK) {
+			s->refmode_eligible = true;
+		} else {
+			s->refmode_eligible = false;
+			RSS_INFO("stream%d: finalized encoder output is not rmem-backed; "
+				 "using embedded ring",
+				 idx);
+		}
+	}
+
 create_ring:
 	/* ── Create ring (or reuse existing across encoder restart) ── */
 	if (s->ring) {
@@ -1686,9 +1701,7 @@ create_ring:
 			/* Refmode: data region unused, minimal placeholder.
 			 * JPEG (paired channels and JPEG-codec streams) stays
 			 * embedded — needs full data region. */
-			if (!s->is_jpeg && s->enc_cfg.codec != RSS_CODEC_JPEG && st->refmode &&
-			    ((st->refmode_shm && st->enc_shm_size[idx] > 0) ||
-			     (!st->refmode_shm && st->rmem_size > 0)))
+			if (s->refmode_eligible)
 				data = 4096;
 
 			s->ring = rss_ring_create(ring_name, slots_cfg, data);

--- a/tests/mock_hal.c
+++ b/tests/mock_hal.c
@@ -421,6 +421,13 @@ static int mock_enc_get_rmem_info(void *ctx, uintptr_t *virt_base, uint32_t *siz
 	return RSS_OK;
 }
 
+static int mock_enc_stream_is_rmem(void *ctx, int chn)
+{
+	(void)ctx;
+	(void)chn;
+	return RSS_OK;
+}
+
 static int mock_enc_get_channel_attr(void *ctx, int chn, rss_video_config_t *cfg)
 {
 	rss_hal_ctx_t *hal = ctx;
@@ -753,6 +760,7 @@ static const rss_hal_ops_t mock_ops = {
 	.enc_request_idr = mock_enc_request_idr,
 	.enc_inject_stream_shm = mock_enc_inject_stream_shm,
 	.enc_get_rmem_info = mock_enc_get_rmem_info,
+	.enc_stream_is_rmem = mock_enc_stream_is_rmem,
 	.enc_set_rc_mode = (void *)mock_ok,
 	.enc_set_bitrate = (void *)mock_ok,
 	.enc_set_gop = (void *)mock_ok,


### PR DESCRIPTION
## Problem

RVD currently treats a kernel rmem reservation as sufficient evidence that encoder output can be published by reference. That is false for OpenIMP T31: DMA uses rmem, but the public Annex-B stream is finalized into ordinary process memory. RVD then creates a 4 KiB reference ring and publishes offsets that do not describe the returned bytes.

## Change

- require per-stream HAL storage attestation before enabling rmem reference mode
- fall back to a normal embedded ring when the finalized output is not externally referenceable
- keep SHM injection reference mode unchanged
- allow `LIB_IMP` to select a link-only complete SDK ABI while a compatible provider such as OpenIMP remains the runtime `libimp.so`

## Dependencies

- gtxaspec/raptor-hal#12
- opensensor/openimp commit `1374dc4`

## Validation

- current upstream Raptor + HAL T31 package-only builds passed
- ASAN/UBSAN host suite: 342 tests and 19,257 assertions passed
- deployed equivalent patch on two T31X/SC301IoT VDB2 devices
- both devices sustained 2048x1536 RTSP and on-demand JPEG; RVD logged the embedded-ring fallback for OpenIMP streams

No firmware image build or flash was used for this PR validation.