### PR TITLE
ric: trust reported luma over sensor gain

### DIFF
--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -351,7 +351,7 @@ position = bottom_right
                               # linear AE histogram and read lower than Gen1/2's
                               # GetAeLuma for the same scene (bright ~50 vs ~100+);
                               # tune per model, not across generations.
-# night_gain = 80000          # total_gain above this -> night (regardless of luma)
+# night_gain = 80000          # gain-only fallback when ae_luma is unavailable
 # day_gain_pct = 25           # night->day: gain below this % of night baseline
 # probe_gain_pct = 90         # night: gain dip below this % of the night
                               # baseline lifts the IR LEDs for an ambient

--- a/ric/ric.h
+++ b/ric/ric.h
@@ -143,7 +143,7 @@ typedef struct {
 
 	/* Luma trigger thresholds */
 	int night_luma;	       /* ae_luma below this → night (default 20, 0-255) */
-	int night_gain;	       /* gain above this → night regardless of luma (default 80000) */
+	int night_gain;	       /* gain fallback when luma is unavailable (default 80000) */
 	int day_gain_pct;      /* night→day: gain below this % of baseline → day (default 25) */
 	int probe_gain_pct;    /* night: gain dip below this % of baseline lifts the IR
 				* LEDs for an ambient luma probe (default 90, 0 = off) */

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -731,8 +731,7 @@ void ric_poll_exposure(ric_state_t *st)
 		 */
 		want_night = have_luma
 				     ? ae_luma < (uint32_t)st->settings.night_luma
-				     : have_gain &&
-					       total_gain > (uint32_t)st->settings.night_gain;
+				     : have_gain && total_gain > (uint32_t)st->settings.night_gain;
 
 		/* Luma is trustworthy for the day direction only while no
 		 * IR bank pours light into the scene: none configured or

--- a/ric/ric_daynight.c
+++ b/ric/ric_daynight.c
@@ -712,11 +712,12 @@ void ric_poll_exposure(ric_state_t *st)
 		/*
 		 * Hybrid luma+gain algorithm (sensor-independent):
 		 *
-		 * Day → Night: ae_luma < night_luma.
+		 * Day -> Night: ae_luma < night_luma.
 		 *   No IR LEDs on in day mode, so ae_luma directly reflects
-		 *   ambient light. Works identically across all sensors.
+		 *   ambient light. If luma is unavailable, night_gain is the
+		 *   compatibility fallback for older HALs.
 		 *
-		 * Night → Day: total_gain < day_gain_pct% of night baseline.
+		 * Night -> Day: total_gain < day_gain_pct% of night baseline.
 		 *   When ambient light returns (dawn, lights on), the ISP
 		 *   drops gain because the scene is bright — even with IR
 		 *   LEDs still on. This ratio is sensor-independent because
@@ -724,11 +725,14 @@ void ric_poll_exposure(ric_state_t *st)
 		 *   ae_luma is NOT used here because IR illumination inflates
 		 *   it regardless of ambient light level.
 		 *
-		 * Each term is gated on its field being reported, so a
-		 * platform missing one runs on the other alone.
+		 * A reported luma value is authoritative for day-to-night.
+		 * Gain scales differ between sensors and SoC generations, so
+		 * gain must not overrule a valid bright-luma reading.
 		 */
-		want_night = (have_luma && ae_luma < (uint32_t)st->settings.night_luma) ||
-			     (have_gain && total_gain > (uint32_t)st->settings.night_gain);
+		want_night = have_luma
+				     ? ae_luma < (uint32_t)st->settings.night_luma
+				     : have_gain &&
+					       total_gain > (uint32_t)st->settings.night_gain;
 
 		/* Luma is trustworthy for the day direction only while no
 		 * IR bank pours light into the scene: none configured or

--- a/tests/ric_harness.py
+++ b/tests/ric_harness.py
@@ -1803,10 +1803,9 @@ def scenario_ctrl_extras(stub, watch):
            "set-threshold: unknown key rejected", str(r))
     ric.stop()
 
-    # night_gain and day_gain_pct retune live too: a bright-luma scene
-    # goes night once its gain sits above a lowered night_gain, and the
-    # baseline ratio releases it once day_gain_pct is raised over the
-    # current gain fraction.
+    # Valid luma is authoritative: lowering night_gain must not turn a
+    # bright scene dark. If luma then becomes unavailable, night_gain is
+    # the fallback; day_gain_pct still controls the night baseline ratio.
     stub.set_scene(luma=120, gain=50000, ev=4000)
     ric = Ric("ctrlx2", LUMA_CONF)
     if not ric.wait_running():
@@ -1817,12 +1816,17 @@ def scenario_ctrl_extras(stub, watch):
     mm = stub.mark()
     ctrl_cmd(RUN_DIR + "/ric.sock",
              {"cmd": "set-threshold", "key": "night_gain", "value": 40000})
+    time.sleep(1.0)
+    result("night" not in stub.modes_since(mm),
+           "set-threshold: gain cannot overrule valid bright luma",
+           str(stub.modes_since(mm)))
+    stub.set_scene(luma=0, gain=50000, ev=4000)
     ok = wait_for(lambda: "night" in stub.modes_since(mm), 4)
-    result(ok, "set-threshold: night_gain drives the gain term live",
+    result(ok, "set-threshold: night_gain covers missing luma",
            str(stub.modes_since(mm)))
     time.sleep((3 + 1) * POLL_MS / 1000.0)  # cooldown: baseline = 50000
     # gain holds at 60% of baseline: below 25% never comes, 70% releases
-    stub.set_scene(luma=120, gain=30000, ev=4000)
+    stub.set_scene(luma=0, gain=30000, ev=4000)
     time.sleep(1.0)
     still_night = "day" not in stub.modes_since(mm)
     ctrl_cmd(RUN_DIR + "/ric.sock",


### PR DESCRIPTION
## Summary

- make valid `ae_luma` authoritative for day-to-night decisions in the luma trigger
- use `night_gain` only when luma is unavailable
- retain gain-only HAL support and the night baseline-ratio day transition
- update configuration documentation and behavioral coverage

## Root cause

The luma trigger ORed its luma and gain terms. T40 reported a bright luma of 100-102 but a sensor-specific total gain of 81158, so the default `night_gain=80000` forced a well-lit camera into night mode. Gain is not comparable across every sensor/SoC and must not overrule a valid luma reading.

## Validation

- T40 Buildroot package cross-build passes with `-Wall -Wextra -Werror`
- ASan/UBSan RIC host binary compiles; the namespace-based harness is skipped by this host because unprivileged user namespaces are disabled
- live Wyze Cam v3 Pro / T40: luma 101-102, gain 81158, deliberately lowered `night_gain=40000`; stayed in day for 8/8 samples
- same camera: raised `night_luma=200`; switched to night through the luma path
- restored `night_luma=20`, `night_gain=80000`, auto mode; camera remains in day and RTSP decodes at 2560x1440