### PR TITLE
rmr: abort segments when the write stream fails

### DIFF
--- a/rmr/rmr.h
+++ b/rmr/rmr.h
@@ -69,6 +69,7 @@ typedef struct {
 	int64_t segment_start_rt_us;	/* wall clock at open (boundary math) */
 	int64_t segment_boundary_rt_us; /* next wall-clock split point */
 	bool segment_idr_requested;	/* one sharpening IDR per boundary */
+	bool segment_write_error;	/* write/flush failure: abort file at close */
 
 	/* Pre-buffer for motion clips (main thread only) */
 	rmr_prebuf_t *video_pb;
@@ -86,6 +87,7 @@ typedef struct {
 	int64_t clip_a_ts_base; /* ring ts mapping base for clip_a_dts steering */
 	int64_t clip_start_us;	/* wall clock when clip opened */
 	uint64_t clip_bytes;
+	bool clip_write_error;	/* write/flush failure: abort file at close */
 
 	/* Timelapse (main thread only) */
 	bool tl_enabled; /* [timelapse] enabled, runtime-togglable */
@@ -97,6 +99,7 @@ typedef struct {
 	uint64_t tl_bytes;
 	uint64_t tl_frames_total;
 	int64_t tl_last_err_us; /* rate-limits open/write failure warns */
+	bool tl_write_error;	/* write/flush failure: abort file at close */
 
 	/* Frame read buffer (main thread only) */
 	uint8_t *frame_buf;

--- a/rmr/rmr_main.c
+++ b/rmr/rmr_main.c
@@ -49,6 +49,14 @@ static int direct_write(const void *buf, uint32_t len, void *ctx)
 			if (errno == ENOSPC) {
 				RSS_ERROR("SD card full, stopping recording");
 				atomic_store(&st->recording, false);
+			} else {
+				/* Storage failed mid-segment (I/O error,
+				 * NFS soft-mount timeout): the file has
+				 * holes where the lost writes should be.
+				 * The current segment is poisoned; abort
+				 * it and let the normal flow start a
+				 * fresh one at the next keyframe. */
+				st->segment_write_error = true;
 			}
 			return -1;
 		}
@@ -80,6 +88,7 @@ static int clip_write(const void *buf, uint32_t len, void *ctx)
 			if (errno == EINTR)
 				continue;
 			RSS_ERROR("clip write error: %s", strerror(errno));
+			st->clip_write_error = true;
 			return -1;
 		}
 	}
@@ -110,6 +119,7 @@ static int tl_write(const void *buf, uint32_t len, void *ctx)
 			if (errno == EINTR)
 				continue;
 			RSS_ERROR("timelapse write error: %s", strerror(errno));
+			st->tl_write_error = true;
 			return -1;
 		}
 	}
@@ -210,8 +220,9 @@ static int start_segment(rmr_state_t *st)
 static void close_segment(rmr_state_t *st)
 {
 	if (st->mux) {
-		rmr_mux_finalize(st->mux);
-		if (st->sign_enabled)
+		if (!st->segment_write_error && rmr_mux_finalize(st->mux) < 0)
+			st->segment_write_error = true;
+		if (!st->segment_write_error && st->sign_enabled)
 			rmr_sign_stream_emit(&st->sign_seg, true, direct_write, st);
 		rmr_mux_destroy(st->mux);
 		st->mux = NULL;
@@ -222,9 +233,15 @@ static void close_segment(rmr_state_t *st)
 
 	if (fd >= 0) {
 		rmr_storage_close_segment(fd);
-		RSS_DEBUG("segment closed: %s (%" PRIu64 " frames, %" PRIu64 " bytes)",
-			  st->segment_path, st->frames_written, st->bytes_written);
+		if (st->segment_write_error)
+			RSS_WARN("segment aborted after write error, file kept: %s",
+				 st->segment_path);
+		else
+			RSS_DEBUG("segment closed: %s (%" PRIu64 " frames, %" PRIu64
+				  " bytes)",
+				  st->segment_path, st->frames_written, st->bytes_written);
 	}
+	st->segment_write_error = false;
 }
 
 /* ── Motion clip management ── */
@@ -250,6 +267,7 @@ static int open_clip(rmr_state_t *st)
 	st->clip_a_ts_base = -1;
 	st->clip_start_us = rss_timestamp_us();
 	st->clip_bytes = 0;
+	st->clip_write_error = false;
 
 	setup_mux_tracks(st->clip_mux, st);
 	if (st->sign_enabled)
@@ -265,18 +283,24 @@ static int open_clip(rmr_state_t *st)
 static void close_clip(rmr_state_t *st)
 {
 	if (st->clip_mux) {
-		rmr_mux_finalize(st->clip_mux);
-		if (st->sign_enabled)
+		if (!st->clip_write_error && rmr_mux_finalize(st->clip_mux) < 0)
+			st->clip_write_error = true;
+		if (!st->clip_write_error && st->sign_enabled)
 			rmr_sign_stream_emit(&st->sign_clip, true, clip_write, st);
 		rmr_mux_destroy(st->clip_mux);
 		st->clip_mux = NULL;
 	}
 	if (st->clip_fd >= 0) {
 		rmr_storage_close_segment(st->clip_fd);
-		RSS_DEBUG("motion clip closed: %s (%" PRIu64 " bytes)", st->clip_path,
-			  st->clip_bytes);
+		if (st->clip_write_error)
+			RSS_WARN("motion clip aborted after write error, file kept: %s",
+				 st->clip_path);
+		else
+			RSS_DEBUG("motion clip closed: %s (%" PRIu64 " bytes)", st->clip_path,
+				  st->clip_bytes);
 		st->clip_fd = -1;
 	}
+	st->clip_write_error = false;
 }
 
 /* ── Timelapse file management ── */
@@ -302,11 +326,16 @@ static void close_timelapse(rmr_state_t *st)
 	}
 	if (st->tl_fd >= 0) {
 		rmr_storage_close_segment(st->tl_fd);
-		RSS_INFO("timelapse file closed: %s (%u frames, %" PRIu64 " bytes)", st->tl_path,
-			 st->tl.frames_in_file, st->tl_bytes);
+		if (st->tl_write_error)
+			RSS_WARN("timelapse file aborted after write error, file kept: %s",
+				 st->tl_path);
+		else
+			RSS_INFO("timelapse file closed: %s (%u frames, %" PRIu64 " bytes)",
+				 st->tl_path, st->tl.frames_in_file, st->tl_bytes);
 		st->tl_fd = -1;
 	}
 	st->tl.file_day = 0;
+	st->tl_write_error = false;
 }
 
 static int open_timelapse(rmr_state_t *st, int32_t day)
@@ -334,6 +363,7 @@ static int open_timelapse(rmr_state_t *st, int32_t day)
 
 	st->tl_fd = fd;
 	st->tl_bytes = 0;
+	st->tl_write_error = false;
 
 	/* Fragment-per-sample: without a next sample to derive from, each
 	 * sample's declared duration must be the playback grid step or the
@@ -367,7 +397,12 @@ static void timelapse_write_sample(rmr_state_t *st, const uint8_t *data, uint32_
 	/* Every sample is a keyframe: fragment-per-sample keeps the file
 	 * valid to the last written frame and chains a signature box per
 	 * sample, mirroring the per-GOP pattern of the other writers. */
-	rmr_mux_flush_fragment(st->tl_mux);
+	if (rmr_mux_flush_fragment(st->tl_mux) < 0) {
+		/* Abort the poisoned file; the next sample reopens. */
+		st->tl_write_error = true;
+		close_timelapse(st);
+		return;
+	}
 	if (st->sign_enabled)
 		rmr_sign_stream_emit(&st->sign_tl, false, tl_write, st);
 
@@ -403,8 +438,9 @@ static void clip_write_video(rmr_state_t *st, const uint8_t *avcc, uint32_t avcc
 	};
 
 	if (is_key) {
-		rmr_mux_flush_fragment(st->clip_mux);
-		if (st->sign_enabled)
+		if (rmr_mux_flush_fragment(st->clip_mux) < 0)
+			st->clip_write_error = true;
+		if (st->sign_enabled && !st->clip_write_error)
 			rmr_sign_stream_emit(&st->sign_clip, false, clip_write, st);
 	}
 	rmr_mux_write_video(st->clip_mux, &vs);
@@ -1062,22 +1098,35 @@ static void record_loop(rmr_state_t *st)
 					st->segment_idr_requested = true;
 				}
 				if (meta.is_key) {
-					rmr_mux_flush_fragment(st->mux);
-					if (st->sign_enabled)
+					if (rmr_mux_flush_fragment(st->mux) < 0)
+						st->segment_write_error = true;
+					if (st->sign_enabled && !st->segment_write_error)
 						rmr_sign_stream_emit(&st->sign_seg, false,
 								     direct_write, st);
 					st->frames_since_flush = 0;
-					if (rmr_storage_should_rotate_at(
-						    st->storage, st->segment_start_rt_us, now_rt)) {
+					if (st->segment_write_error) {
+						/* The write stream broke (I/O
+						 * error, NFS timeout): stop
+						 * writing to this file (left in
+						 * place). The normal flow below
+						 * starts a fresh one at the next
+						 * keyframe. */
+						close_segment(st);
+					} else if (rmr_storage_should_rotate_at(
+							   st->storage, st->segment_start_rt_us,
+							   now_rt)) {
 						close_segment(st);
 						rmr_storage_enforce_limit(st->storage);
 					}
 				} else if (st->frames_since_flush >= 10) {
-					rmr_mux_flush_fragment(st->mux);
-					if (st->sign_enabled)
+					if (rmr_mux_flush_fragment(st->mux) < 0)
+						st->segment_write_error = true;
+					if (st->sign_enabled && !st->segment_write_error)
 						rmr_sign_stream_emit(&st->sign_seg, false,
 								     direct_write, st);
 					st->frames_since_flush = 0;
+					if (st->segment_write_error)
+						close_segment(st);
 				}
 			}
 


### PR DESCRIPTION
## Problem

When a `write()` to the segment file fails (I/O error, NFS soft-mount `ETIMEDOUT`), rmr only dropped the in-flight buffer and kept appending subsequent fragments to the same file. On soft/`softerr` NFS mounts whose backing pages were discarded on RPC timeout, that produced MP4s with permanent blank blocks mid-file wherever the writeback was lost.

`bb_flush()` also advanced `bytes_written` past the failed box unconditionally, and the return value of `rmr_mux_flush_fragment()` was ignored by all three callers, so nothing ever short-circuited the file.

## Fix

Mirror the shape of prudynt-t `91650d76a` (`0001-mp4-recorder-check-write-errors.patch`): each write context tracks a write-error flag and a failed fragment flush aborts the file immediately.

- `direct_write()`: a non-`EINTR` write error other than `ENOSPC` marks the segment as failed. (`ENOSPC` keeps its existing dedicated handling: it stops recording.)
- `clip_write()` / `tl_write()`: same flag on the motion-clip and timelapse writers.
- Main loop / clip / timelapse: check `rmr_mux_flush_fragment()` return; on failure abort the file right away instead of writing the next fragment into it.
- `close_segment()` / `close_clip()` / `close_timelapse()`: `rmr_mux_finalize()` failures mark the file too (tail-flush errors), and the final signature box is no longer emitted over a broken write stream.

After an abort the existing flow takes over unchanged: the next keyframe opens a **fresh** segment, timelapse reopens on its next sample, and the storage-standby path (`rmr_storage_available()`) still governs whether an open can succeed at all.

**The aborted file is left in place on disk, not deleted.** Upstream opens segments directly under their final names and there is no `.tmp`/rename staging, so any rename/quarantine scheme would be extra machinery; the warning log (`segment aborted after write error, file kept: <path>`) identifies affected files. Bytes up to the last successful flush are as good as they will ever be; everything after is untrusted.

## Detection on default async mounts

On async NFS mounts `write()` copies data into the page cache and returns; the WRITE RPC that actually fails runs later in background writeback. The error is not lost: the kernel caches it and reports it on a **subsequent `write()` to the same file**, not on the call that dirtied the page — `EIO`/`ETIMEDOUT` landing in later `write()`s is exactly the behavior observed in the field. rmr flushes a fragment at least once per keyframe (10 frames max between flushes), so `direct_write()` encounters the pending error within one fragment and the abort path fires on default async mounts too — no sync-class mount flag required.

`fsync()` at `rmr_storage_close_segment()` remains an additional end-of-segment checkpoint (return value currently unchecked upstream); it is not the only channel through which async writeback errors surface.

## Validation

- Code review only; not yet exercised on hardware with a failing write path.



---

**Related Discord discussion:** https://discord.com/channels/1086012062649565286/1545394391470964737