### PR TITLE
rvd: don't let the OSD estimate pin stream resolution to a placeholder

### DIFF
--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -653,6 +653,27 @@ static void osd_pool_cb(const char *section, void *ud)
 	}
 }
 
+/* Read an int without rss_config_get_int's populate-on-miss side effect.
+ *
+ * rss_config_get_int stores the default back into the section when the key is
+ * absent, so a later read of the same key with a different default sees this
+ * first one instead of its own. That is wrong for a placeholder read taken
+ * before the real value is known: the OSD pool estimate below reads the stream
+ * dimensions with stand-in defaults (the sensor resolution is not queried until
+ * after HAL init), and load_stream_config reads them again with the
+ * sensor-derived default. A populating read here would pin every stream to the
+ * stand-in and quietly downscale a full-resolution sensor to it. */
+static int cfg_peek_int(rss_config_t *cfg, const char *section, const char *key, int def)
+{
+	const char *val = rss_config_get_str(cfg, section, key, NULL);
+	if (!val)
+		return def;
+
+	char *end;
+	long v = strtol(val, &end, 0);
+	return end == val ? def : (int)v;
+}
+
 int rvd_pipeline_init(rvd_state_t *st)
 {
 	rss_config_t *cfg = st->cfg;
@@ -782,16 +803,23 @@ int rvd_pipeline_init(rvd_state_t *st)
 	 * finds nothing once the previous instance has deinitialized) —
 	 * so unset stream dims fall back to a 4MP-class ceiling for POOL
 	 * sizing only. The streams themselves resolve their dims after
-	 * init from the sensor; the values stored by these reads are
-	 * display-only and never become configuration. */
+	 * init from the sensor, which is why these reads must not store
+	 * anything: rss_config_get_int populates the section on a miss,
+	 * and that is what used to pin every stream to the stand-in.
+	 * cfg_peek_int does not. */
 	{
 		int font_size = rss_config_get_int(cfg, "osd", "font_size", 24);
 		if (font_size < 10)
 			font_size = 10;
-		int main_w = rss_config_get_int(cfg, "stream0", "width", 2560);
-		int main_h = rss_config_get_int(cfg, "stream0", "height", 1440);
-		int sub_w = rss_config_get_int(cfg, "stream1", "width", 640);
-		int sub_h = rss_config_get_int(cfg, "stream1", "height", 360);
+		/* Placeholder dimensions for the estimate only — read without
+		 * populating, so the sensor's true resolution still reaches the
+		 * streams (see cfg_peek_int). They scale the sub-stream region as
+		 * a ratio of the main, so a stand-in that differs from the eventual
+		 * resolution only nudges the estimate, which carries headroom. */
+		int main_w = cfg_peek_int(cfg, "stream0", "width", 2560);
+		int main_h = cfg_peek_int(cfg, "stream0", "height", 1440);
+		int sub_w = cfg_peek_int(cfg, "stream1", "width", 640);
+		int sub_h = cfg_peek_int(cfg, "stream1", "height", 360);
 		bool has_sub = rss_config_get_bool(cfg, "stream1", "enabled", true);
 
 		uint32_t osd_pool = 0;


### PR DESCRIPTION
The OSD pool has to be sized before HAL init, which is before the sensor's true
resolution can be known, so the estimate reads the stream dimensions with
stand-in defaults. The comment above that block says the stand-ins are
"display-only and never become configuration".

They are not. `rss_config_get_int` stores its default back into the section on a
miss, so those reads write `2560x1440` into `[stream0]`. `load_stream_config`
reads the same keys later with the sensor-derived default, finds the stand-in
sitting there, and returns it.

The result is that a sensor larger than the stand-in is silently downscaled to
it whenever `[stream0]` width/height are left unset — which is the documented way
to let the sensor decide. On the procfs backends the sensor-derived default comes
from `/proc/jz/sensor`, so T40/T41 are capped the same way. Nothing logs it; the
stream simply comes out at the placeholder resolution.

The fix is a non-populating read for the placeholder values, so the section stays
unset and each real read sees its own default. The estimate only uses these as a
sub/main ratio carrying headroom, so a stand-in that differs from the eventual
resolution costs it nothing — which is why the stand-in values themselves are
left exactly as they are.

The stale comment is corrected to say why the reads must not store, rather than
asserting they don't.

Cut from `main`, one commit, one file. Host test suite: 342 pass, 0 fail.
`git-clang-format` against clang-format 19 is clean.

https://claude.ai/code/session_0135iarzELmev2nXzBx4SFLU