### PR TITLE
rvd: size a JPEG ring to hold one of its own frames

### DIFF
--- a/build-asan.sh
+++ b/build-asan.sh
@@ -434,7 +434,8 @@ $CC $CFLAGS $HAL_CFLAGS -c "$RAPTOR_DIR/rvd/rvd_frame_loop.c" -o "$OUT/rvd_frame
 $CC $CFLAGS $HAL_CFLAGS -c "$RAPTOR_DIR/rvd/rvd_ctrl.c" -o "$OUT/rvd_ctrl.o"
 $CC $CFLAGS $HAL_CFLAGS -c "$RAPTOR_DIR/rvd/rvd_osd.c" -o "$OUT/rvd_osd.o"
 $CC $CFLAGS $HAL_CFLAGS -c "$RAPTOR_DIR/rvd/rvd_ivs.c" -o "$OUT/rvd_ivs.o"
-$CC -o "$OUT/rvd" "$OUT"/rvd_main.o "$OUT"/rvd_pipeline.o "$OUT"/rvd_frame_loop.o "$OUT"/rvd_ctrl.o "$OUT"/rvd_osd.o "$OUT"/rvd_ivs.o $LIBS_HAL $LDFLAGS
+$CC $CFLAGS $HAL_CFLAGS -c "$RAPTOR_DIR/rvd/rvd_ring_size.c" -o "$OUT/rvd_ring_size.o"
+$CC -o "$OUT/rvd" "$OUT"/rvd_main.o "$OUT"/rvd_pipeline.o "$OUT"/rvd_frame_loop.o "$OUT"/rvd_ctrl.o "$OUT"/rvd_osd.o "$OUT"/rvd_ivs.o "$OUT"/rvd_ring_size.o $LIBS_HAL $LDFLAGS
 echo "  -> rvd"
 
 echo "=== RAD (mock HAL) ==="

--- a/rvd/Makefile
+++ b/rvd/Makefile
@@ -1,4 +1,4 @@
-SRCS := rvd_main.c rvd_pipeline.c rvd_frame_loop.c rvd_ctrl.c rvd_osd.c rvd_ivs.c
+SRCS := rvd_main.c rvd_pipeline.c rvd_frame_loop.c rvd_ctrl.c rvd_osd.c rvd_ivs.c rvd_ring_size.c
 OBJS := $(SRCS:.c=.o)
 BIN  := rvd
 

--- a/rvd/rvd_pipeline.c
+++ b/rvd/rvd_pipeline.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include "rvd.h"
+#include "rvd_ring_size.h"
 
 #define RVD_PAGE_SIZE 4096u
 
@@ -1598,14 +1599,8 @@ create_ring:
 			uint32_t h = s->enc_cfg.height;
 			uint32_t q = (uint32_t)s->enc_cfg.init_qp;
 			uint32_t fps = s->enc_cfg.fps_num;
-			uint32_t divisor = (q >= 90) ? 6 : (q >= 70) ? 16 : 24;
-			uint32_t slots = (fps >= 9) ? 16 : (fps >= 3) ? 8 : 4;
-			uint32_t jpeg_max = w * h / divisor;
-			if (jpeg_max < 16384)
-				jpeg_max = 16384;
-			uint32_t data = jpeg_max * slots;
-			if (data > 4 * 1024 * 1024)
-				data = 4 * 1024 * 1024;
+			uint32_t slots = rvd_jpeg_ring_slots(fps);
+			uint32_t data = rvd_jpeg_ring_data(w, h, q, fps);
 
 			s->ring = rss_ring_create(ring_name, slots, data);
 			if (s->ring)

--- a/rvd/rvd_ring_size.c
+++ b/rvd/rvd_ring_size.c
@@ -1,0 +1,62 @@
+/*
+ * rvd_ring_size.c -- how big a JPEG ring has to be.
+ *
+ * Kept apart from the pipeline so the arithmetic can be exercised
+ * without a HAL: it is a heuristic over an encoder nobody can predict,
+ * and the failure it produces is silent.
+ */
+
+#include "rvd_ring_size.h"
+
+uint32_t rvd_jpeg_ring_slots(uint32_t fps)
+{
+	return (fps >= 9) ? 16 : (fps >= 3) ? 8 : 4;
+}
+
+uint32_t rvd_jpeg_frame_bound(uint32_t w, uint32_t h)
+{
+	/*
+	 * An upper bound on one encoded frame, not an average.
+	 *
+	 * Measured bytes per pixel at quality 75 spans 0.068 on a quiet
+	 * 2304x1296 scene to 0.309 on a detailed 640x480 downscale of a
+	 * 5MP sensor -- the same picture costs proportionally more the
+	 * smaller it is scaled, because the headers do not shrink with
+	 * it and neither does the noise. Half a byte per pixel covers
+	 * the worst of that with room over, and the fixed term keeps a
+	 * small picture from being bounded by its pixel count alone.
+	 */
+	return w * h / 2 + 32768;
+}
+
+uint32_t rvd_jpeg_ring_data(uint32_t w, uint32_t h, uint32_t quality, uint32_t fps)
+{
+	uint32_t divisor = (quality >= 90) ? 6 : (quality >= 70) ? 16 : 24;
+	uint32_t jpeg_avg = w * h / divisor;
+	uint32_t bound = rvd_jpeg_frame_bound(w, h);
+	uint32_t data;
+
+	if (jpeg_avg < 16384)
+		jpeg_avg = 16384;
+
+	data = jpeg_avg * rvd_jpeg_ring_slots(fps);
+	if (data > RVD_JPEG_RING_MAX)
+		data = RVD_JPEG_RING_MAX;
+
+	/*
+	 * The pool has to hold one whole frame. rss_ring_publish refuses
+	 * a frame larger than the data region outright, so a pool under
+	 * that size is not backpressure that clears on the next frame
+	 * but a channel that can never publish again -- the snapshot
+	 * endpoint then waits for a frame that will not come. The
+	 * estimate above is an average and runs several times under the
+	 * bound on a detailed scene, so raise the pool to fit rather
+	 * than trusting the slot count to cover the gap. This wins over
+	 * the cap: a ring too small to carry its own frames is worth
+	 * less than the memory it saves.
+	 */
+	if (data < bound)
+		data = bound;
+
+	return data;
+}

--- a/rvd/rvd_ring_size.h
+++ b/rvd/rvd_ring_size.h
@@ -1,0 +1,19 @@
+#ifndef RVD_RING_SIZE_H
+#define RVD_RING_SIZE_H
+
+#include <stdint.h>
+
+/* Ceiling on a JPEG ring's data region, before the one-frame floor. */
+#define RVD_JPEG_RING_MAX (4 * 1024 * 1024)
+
+/* Slot count for a JPEG ring at this frame rate; always a power of two. */
+uint32_t rvd_jpeg_ring_slots(uint32_t fps);
+
+/* Upper bound on a single encoded JPEG of these dimensions. */
+uint32_t rvd_jpeg_frame_bound(uint32_t w, uint32_t h);
+
+/* Size of a JPEG ring's data region: the slot estimate, capped, then
+ * raised to hold one whole frame. */
+uint32_t rvd_jpeg_ring_data(uint32_t w, uint32_t h, uint32_t quality, uint32_t fps);
+
+#endif /* RVD_RING_SIZE_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,7 +22,8 @@ LDFLAGS = $(SAN_FLAGS) -lpthread -lrt -lm
 
 TEST_SRCS = main.c test_ric_json.c test_nal.c test_prebuf.c test_mux.c test_codec.c test_sdp.c test_ring.c test_rsp.c \
             test_ctrl.c test_sign.c test_storage.c test_timelapse.c test_sendq.c test_idr_recovery.c test_rwd_sendq.c test_rwd_pacer.c test_rwd_rtcp.c test_rad_clock.c test_media_clock.c test_resync.c test_vui.c \
-            test_backchannel.c test_config.c test_rhd_slots.c
+            test_backchannel.c test_config.c test_rhd_slots.c \
+            test_ring_size.c ../rvd/rvd_ring_size.c
 LIB_SRCS = ../ric/ric_json.c ../rsd/rsd_sendq.c ../rsd/rsd_backchannel.c ../rwd/rwd_sendq.c ../rwd/rwd_pacer.c ../rad/rad_clock.c ../rad/rad_resync.c ../rmr/rmr_nal.c ../rmr/rmr_prebuf.c ../rmr/rmr_mux.c ../rmr/rmr_sign.c ../rmr/rmr_timelapse.c ../../raptor-common/src/rss_media_clock.c ../../raptor-common/src/rss_vui.c ../../raptor-common/src/rss_sign.c ../../raptor-common/src/rss_jpeg.c ../../raptor-common/src/rss_aac.c ../rmr/rmr_storage.c \
            ../../raptor-common/src/rss_util.c ../../raptor-common/src/rss_log.c \
            ../../raptor-common/src/cJSON.c \

--- a/tests/main.c
+++ b/tests/main.c
@@ -8,6 +8,7 @@ extern SUITE(sdp_suite);
 extern SUITE(codec_suite);
 extern SUITE(ring_suite);
 extern SUITE(vui_suite);
+extern SUITE(ring_size_suite);
 extern SUITE(rsp_url_suite);
 extern SUITE(rsp_amf0_suite);
 extern SUITE(rsp_chunk_suite);
@@ -44,6 +45,7 @@ int main(int argc, char **argv)
 	RUN_SUITE(codec_suite);
 	RUN_SUITE(ring_suite);
 	RUN_SUITE(vui_suite);
+	RUN_SUITE(ring_size_suite);
 	RUN_SUITE(rsp_url_suite);
 	RUN_SUITE(rsp_amf0_suite);
 	RUN_SUITE(rsp_chunk_suite);

--- a/tests/test_ring_size.c
+++ b/tests/test_ring_size.c
@@ -1,0 +1,98 @@
+#include "greatest.h"
+#include "rvd_ring_size.h"
+
+/*
+ * Frames measured off two cameras at quality 75. They sit at opposite
+ * ends of what the encoder produces per pixel, which is what makes a
+ * single average estimate unable to serve both.
+ */
+#define IMX335_MAIN_W	  2560
+#define IMX335_MAIN_H	  1920
+#define IMX335_MAIN_FRAME 1214713 /* 0.247 bytes/pixel */
+
+#define IMX335_SUB_W	  640
+#define IMX335_SUB_H	  480
+#define IMX335_SUB_FRAME  94848 /* 0.309 bytes/pixel */
+
+#define SSC333_MAIN_W	  2304
+#define SSC333_MAIN_H	  1296
+#define SSC333_MAIN_FRAME 204120 /* 0.068 bytes/pixel */
+
+#define SSC333_SUB_W	  640
+#define SSC333_SUB_H	  360
+#define SSC333_SUB_FRAME  23397 /* 0.102 bytes/pixel */
+
+TEST a_ring_holds_a_whole_frame_from_either_camera(void)
+{
+	/* A pool smaller than one frame cannot ever publish: the ring
+	 * rejects an oversized frame rather than waiting for room. */
+	ASSERT_GTm("imx335 main", rvd_jpeg_ring_data(IMX335_MAIN_W, IMX335_MAIN_H, 75, 1),
+		   IMX335_MAIN_FRAME);
+	ASSERT_GTm("imx335 sub", rvd_jpeg_ring_data(IMX335_SUB_W, IMX335_SUB_H, 75, 1),
+		   IMX335_SUB_FRAME);
+	ASSERT_GTm("ssc333 main", rvd_jpeg_ring_data(SSC333_MAIN_W, SSC333_MAIN_H, 75, 1),
+		   SSC333_MAIN_FRAME);
+	ASSERT_GTm("ssc333 sub", rvd_jpeg_ring_data(SSC333_SUB_W, SSC333_SUB_H, 75, 1),
+		   SSC333_SUB_FRAME);
+	PASS();
+}
+
+TEST the_one_frame_floor_outranks_the_cap(void)
+{
+	/* The cap exists to bound a pool of many frames. A sensor whose
+	 * single frame is bigger than the cap must still get a ring it
+	 * can publish into. */
+	uint32_t w = 4096, h = 3072;
+	uint32_t data = rvd_jpeg_ring_data(w, h, 75, 1);
+
+	ASSERT_GTm("floor was applied over the cap", data, (uint32_t)RVD_JPEG_RING_MAX);
+	ASSERT_EQ(rvd_jpeg_frame_bound(w, h), data);
+	PASS();
+}
+
+TEST a_quiet_camera_is_not_made_to_pay_for_a_busy_one(void)
+{
+	/* The floor is a floor. Where the slot estimate already clears
+	 * one frame -- a high frame rate earns more slots -- the ring
+	 * keeps the size the estimate asked for. */
+	uint32_t sixteen_slots = rvd_jpeg_ring_data(SSC333_MAIN_W, SSC333_MAIN_H, 75, 10);
+	uint32_t estimate = (SSC333_MAIN_W * SSC333_MAIN_H / 16) * 16;
+
+	ASSERT_EQm("16 slots at fps 10", 16, rvd_jpeg_ring_slots(10));
+	ASSERT_EQm("estimate stands on its own", estimate, sixteen_slots);
+	ASSERT_GTm("and it clears the floor", sixteen_slots,
+		   rvd_jpeg_frame_bound(SSC333_MAIN_W, SSC333_MAIN_H));
+	PASS();
+}
+
+TEST slots_stay_a_power_of_two(void)
+{
+	/* rss_ring_create refuses anything else, and answers by
+	 * returning NULL -- which reaches the caller as a ring that
+	 * could not be made, naming nothing about why. */
+	uint32_t fps[] = {0, 1, 2, 3, 5, 8, 9, 15, 25, 30, 60};
+
+	for (size_t i = 0; i < sizeof(fps) / sizeof(fps[0]); i++) {
+		uint32_t s = rvd_jpeg_ring_slots(fps[i]);
+		ASSERT_EQm("power of two", 0u, s & (s - 1));
+		ASSERT_GTm("at least one slot", s, 0u);
+	}
+	PASS();
+}
+
+TEST a_small_picture_is_bounded_by_more_than_its_pixels(void)
+{
+	/* Headers do not shrink with the picture. A bound that is
+	 * pixels alone goes to nothing as the stream gets smaller. */
+	ASSERT_GTm("160x120 clears a JPEG's fixed cost", rvd_jpeg_frame_bound(160, 120), 32768u);
+	PASS();
+}
+
+SUITE(ring_size_suite)
+{
+	RUN_TEST(a_ring_holds_a_whole_frame_from_either_camera);
+	RUN_TEST(the_one_frame_floor_outranks_the_cap);
+	RUN_TEST(a_quiet_camera_is_not_made_to_pay_for_a_busy_one);
+	RUN_TEST(slots_stay_a_power_of_two);
+	RUN_TEST(a_small_picture_is_bounded_by_more_than_its_pixels);
+}


### PR DESCRIPTION
`rss_ring_publish` refuses a frame larger than the whole data region. A JPEG ring
sized under that never publishes again: the snapshot endpoint waits out its
timeout and answers 503, once per frame, forever. Nothing logs it as a sizing
fault, which is what makes it expensive to find.

The ring is sized from an average — `width * height / 16` at quality 75, times a
slot count derived from the frame rate. That average is scene and sensor
dependent in a way a single divisor cannot follow. Measured at the same quality:

| picture | bytes/pixel |
|---|---|
| IMX335, detailed 2560x1920 | 0.247 |
| the 640x480 scaled from it | 0.309 |
| a quieter 2304x1296 camera | 0.068 |

A spread of four and a half times, with the *small* picture the most expensive
per pixel, because the headers do not scale down with it and neither does the
noise. At one frame a second a ring gets four slots, and four times an estimate
five times under the truth is smaller than a single frame.

So bound one frame at half a byte per pixel plus a fixed allowance, and raise the
pool to fit it. **The bound outranks the 4MB cap**: a ring too small to carry its
own frames is worth less than the memory it saves. Where the slot estimate
already clears the bound — which is where a higher frame rate has earned more
slots — nothing changes, so the common configurations are untouched.

The arithmetic moves to `rvd_ring_size.c` so it can be exercised without a HAL.
It is a heuristic over an encoder nobody can predict and it failed silently for
months; five cases pin the ones that mattered.

Cut from `main`, one commit. Host test suite: 347 pass, 0 fail (342 + the new
`ring_size_suite`). `git-clang-format` against clang-format 19 is clean.

https://claude.ai/code/session_0135iarzELmev2nXzBx4SFLU