### PR TITLE
rvd: stop swallowing enc_start failures on the JPEG channel

### DIFF
--- a/rvd/rvd_frame_loop.c
+++ b/rvd/rvd_frame_loop.c
@@ -155,7 +155,24 @@ void *rvd_encoder_thread(void *arg)
 					}
 				}
 				had_readers = true;
-				RSS_HAL_CALL(st->ops, enc_start, st->hal_ctx, s->chn);
+				/*
+				 * Marking the stream enabled after an enc_start
+				 * that failed leaves rvd's view and the
+				 * encoder's disagreeing, and the disagreement
+				 * surfaces somewhere else entirely: the IDR
+				 * check below is the next statement to run, so
+				 * the first visible symptom is
+				 * MI_ERR_VENC_CHN_NOT_STARTED against a channel
+				 * this loop believes it started. Report the
+				 * start failure where it happens, and retry.
+				 */
+				int sret = RSS_HAL_CALL(st->ops, enc_start, st->hal_ctx, s->chn);
+				if (sret != RSS_OK) {
+					RSS_WARN("jpeg chn %d: enc_start failed (%d), retrying",
+						 s->chn, sret);
+					usleep(100000);
+					continue;
+				}
 				s->enabled = true;
 				RSS_DEBUG("jpeg chn %d: started (%u consumers)", s->chn,
 					  rss_ring_reader_count(s->ring));

--- a/rvd/rvd_frame_loop.c
+++ b/rvd/rvd_frame_loop.c
@@ -75,6 +75,7 @@ void *rvd_encoder_thread(void *arg)
 	uint64_t frame_count = 0;
 	int64_t last_pub_warn_us = 0;
 	int poll_errors = 0;
+	int empty_polls = 0;
 	int64_t last_stats = rss_timestamp_us();
 	int64_t last_reap = last_stats;
 	int64_t last_utc = 0; /* 0 = publish on first frame */
@@ -206,8 +207,23 @@ void *rvd_encoder_thread(void *arg)
 
 		rss_frame_t frame;
 		ret = RSS_HAL_CALL(st->ops, enc_get_frame, st->hal_ctx, s->chn, &frame);
-		if (ret == -EAGAIN)
-			continue; /* no frame this time (empty stream / JPEG fps divider) */
+		if (ret == -EAGAIN) {
+			/*
+			 * No frame this time -- routine on its own (empty stream,
+			 * JPEG fps divider). Sustained is not: the poll said the
+			 * encoder was ready every time and it yielded nothing, so
+			 * the channel is bound to something that never produces.
+			 * Say so, because the silent version of this state is
+			 * indistinguishable from an idle on-demand JPEG channel,
+			 * which is what makes it expensive to find.
+			 */
+			if (++empty_polls == 10)
+				RSS_WARN("stream%d: chn %d ready but yielding no frames -- "
+					 "check its source is bound and producing",
+					 idx, s->chn);
+			continue;
+		}
+		empty_polls = 0;
 		if (ret != RSS_OK) {
 			RSS_WARN("stream%d: enc_get_frame failed (chn %d, ret=%d)", idx, s->chn,
 				 ret);


### PR DESCRIPTION
Two commits on the same failure, the fix first.

**1. `enc_start` failures were ignored on the JPEG arm.** The h264 arm beside it
checks the return, logs, and stops the thread. The JPEG arm called `enc_start`
and dropped what it returned, so a channel that refused to start sat in the poll
loop producing nothing — with no error, no warning, and a `/snap` that 503s on
its deadline with the fault three layers away.

**2. A channel that is ready and yields nothing now says so.** `enc_poll`
succeeding and `enc_get_frame` returning `-EAGAIN` was an unlogged `continue`.
That is routine on its own — an empty stream, the JPEG fps divider — but
sustained it means the poll said the encoder was ready every time and it yielded
nothing, so the channel is bound to something that never produces. Silently, that
state is indistinguishable from an idle on-demand JPEG channel, which is what
made it cost a board round-trip rather than a grep.

Warns after ten consecutive occurrences, matching the `poll_errors` counter
beside it, and resets on the first frame. Diagnostic only — it does not touch the
bind it reports on.

Cut from `main`, two commits, one file. Host test suite: 342 pass, 0 fail.
`git-clang-format` against clang-format 19 is clean.

https://claude.ai/code/session_0135iarzELmev2nXzBx4SFLU