### PR TITLE
rvd: never the OOM killer's pick, and give it ten seconds to stop

### DIFF
--- a/config/S31raptor
+++ b/config/S31raptor
@@ -119,11 +119,13 @@ start() {
 	echo "Done."
 }
 
+# stop_daemon <name> [tenths of a second before SIGKILL, default 30]
 stop_daemon() {
 	pid=$(pidof "$1") || return
+	grace=${2:-30}
 	kill "$pid" 2>/dev/null
 	i=0
-	while [ $i -lt 30 ] && kill -0 "$pid" 2>/dev/null; do
+	while [ $i -lt $grace ] && kill -0 "$pid" 2>/dev/null; do
 		sleep 0.1
 		i=$((i + 1))
 	done
@@ -139,9 +141,18 @@ stop() {
 	echo "Stopping Raptor Streaming System..."
 
 	# Stop consumers first, then producer (RVD) last
-	for d in rsr rsp rwd rmd rmr ric rhd rsd rod rad rvd; do
+	for d in rsr rsp rwd rmd rmr ric rhd rsd rod rad; do
 		stop_daemon $d
 	done
+
+	# rvd gets ten seconds, not three. Its teardown is the vendor
+	# pipeline's, and SIGKILL in the middle of it is what leaves a board
+	# needing a reboot: on HiSilicon the ISP driver keeps the CMA pages
+	# the dead process was freeing ("still in use") and the next rvd
+	# blocks in the driver forever. A clean HiSilicon teardown takes 1.5 s
+	# and the HAL's own worst case -- the 3A thread failing to return and
+	# being abandoned after its 2 s join timeout -- takes it past three.
+	stop_daemon rvd 100
 
 	# Clean up runtime files
 	rm -f "$RUNDIR"/*.pid "$RUNDIR"/*.sock

--- a/rvd/rvd_main.c
+++ b/rvd/rvd_main.c
@@ -5,6 +5,7 @@
  * and runs the frame acquisition loop until signaled to stop.
  */
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -36,6 +37,77 @@ void rss_post_banner_hook(const char *name)
 	rss_hal_check_platform(name);
 }
 
+/*
+ * rvd must never be the OOM killer's choice.
+ *
+ * The kernel picks the process with the most resident memory, and rvd's
+ * count includes every shared ring its consumers map, so on a camera it is
+ * the pick every time: score 306 on an SSC333, 58 on a Hi3516EV300, the
+ * largest in both tables. It is also the one process whose death frees
+ * nothing. The pipeline's buffers are the kernel's, not rvd's; a SIGKILL
+ * mid-ioctl leaves the ISP driver holding CMA pages it then reports "still
+ * in use", the next rvd blocks in the driver's semaphore, and only a reboot
+ * clears it. Killing any consumer instead costs a stream for the seconds
+ * the init script takes to bring it back.
+ *
+ * -1000 is OOM_SCORE_ADJ_MIN: never chosen. With nothing killable left the
+ * kernel panics, and the panic= in the bootargs reboots the board -- the
+ * same recovery the wedge needs, without the hours of not knowing.
+ */
+static void rvd_oom_shield(void)
+{
+	FILE *fp = fopen("/proc/self/oom_score_adj", "w");
+	if (!fp) {
+		RSS_WARN("oom_score_adj: %s -- rvd stays the OOM killer's first pick",
+			 strerror(errno));
+		return;
+	}
+	if (fputs("-1000\n", fp) < 0 || fclose(fp) != 0)
+		RSS_WARN("oom_score_adj: write failed: %s -- rvd stays the OOM killer's first pick",
+			 strerror(errno));
+}
+
+/*
+ * One line the next out-of-memory report can be read against. On a board
+ * with a CMA reserve the number that matters is not MemFree, most of which
+ * is CMA the kernel cannot use for its own allocations, but what is left
+ * outside the reserve: 24.8 MiB on a 128 MiB Hi3516EV300 with mmz=96M,
+ * of which about 2 MiB is free while rvd runs.
+ */
+static void rvd_log_memory_headroom(void)
+{
+	FILE *fp = fopen("/proc/meminfo", "r");
+	unsigned long total = 0, avail = 0, cma_total = 0, cma_free = 0, mem_free = 0;
+	char line[128];
+
+	if (!fp)
+		return;
+	while (fgets(line, sizeof(line), fp)) {
+		unsigned long kb;
+		if (sscanf(line, "MemTotal: %lu", &kb) == 1)
+			total = kb;
+		else if (sscanf(line, "MemFree: %lu", &kb) == 1)
+			mem_free = kb;
+		else if (sscanf(line, "MemAvailable: %lu", &kb) == 1)
+			avail = kb;
+		else if (sscanf(line, "CmaTotal: %lu", &kb) == 1)
+			cma_total = kb;
+		else if (sscanf(line, "CmaFree: %lu", &kb) == 1)
+			cma_free = kb;
+	}
+	fclose(fp);
+
+	if (cma_total)
+		RSS_INFO("mem: %lu MiB, %lu MiB of it a CMA reserve; outside the reserve %lu MiB "
+			 "with %lu MiB free (%lu MiB reclaimable)",
+			 total >> 10, cma_total >> 10, (total - cma_total) >> 10,
+			 mem_free > cma_free ? (mem_free - cma_free) >> 10 : 0,
+			 avail > mem_free ? (avail - mem_free) >> 10 : 0);
+	else
+		RSS_INFO("mem: %lu MiB, %lu MiB free, %lu MiB available", total >> 10,
+			 mem_free >> 10, avail >> 10);
+}
+
 int main(int argc, char **argv)
 {
 	rss_daemon_ctx_t ctx;
@@ -43,6 +115,8 @@ int main(int argc, char **argv)
 	if (ret != 0)
 		return ret < 0 ? 1 : 0;
 	rss_hal_set_log_func(hal_log_bridge);
+	rvd_oom_shield();
+	rvd_log_memory_headroom();
 
 	/* Initialize state */
 	rvd_state_t st = {0};


### PR DESCRIPTION
Four `S31raptor restart`s in a row wedged a camera until reboot. The chain was
the OOM killer SIGKILLing the outgoing rvd mid-teardown, the ISP driver left
holding the pages it was freeing (`1 pages are still in use!`), and every later
rvd blocking in the driver. Restarts themselves leak nothing — a clean teardown
returns the pool to its idle figure, measured over five in a row.

**Why rvd is always the one killed.** The kernel picks by resident size, and
rvd's resident size includes every shared ring its consumers map. That is
raptor's own design, not a vendor's, so rvd is the pick on any board with a media
pool big enough to matter — score 306 on one part, 58 on another, the largest in
both tables. It is also the one process whose death frees nothing: the pipeline's
buffers belong to the kernel, not to rvd, so killing it costs a reboot and
reclaims none of the memory that was under pressure.

rvd now sets `oom_score_adj` to `-1000`. A consumer dies instead, and the init
script brings it back. With nothing killable left the kernel panics, and `panic=`
in the bootargs reboots the board — the same recovery the wedge needs, without
the hours of not knowing.

The startup log gains one line the next out-of-memory report can be read against.
Where a CMA reserve exists `MemFree` is the wrong number — most of it is reserve
the kernel cannot use for its own allocations — so the line separates the two and
falls back to the plain figures where there is no reserve.

**Init script.** `stop_daemon` takes a grace period and rvd gets ten seconds
rather than three, because the shutdown this protects against is also the one the
init script can cause. A HAL teardown runs 1.5 s, and its documented worst case —
the 3A thread failing to return and being abandoned after a 2 s join timeout —
takes it past the old limit. Every other daemon keeps three.

Cut from `main`, one commit, two files. Host test suite: 342 pass, 0 fail.
`git-clang-format` against clang-format 19 is clean, `sh -n` clean on the init
script.

https://claude.ai/code/session_0135iarzELmev2nXzBx4SFLU