### PR TITLE
conformity: read the JSON rule over runs of literals, not over lines

### DIFF
--- a/tools/conformity/README.md
+++ b/tools/conformity/README.md
@@ -21,7 +21,7 @@ Checks:
 | Token | What it does |
 |-------|--------------|
 | `format` | diff-scoped `git-clang-format-19` (staged at commit, outgoing range at push), same exclusions as CI |
-| `json-gate` | no hand-written JSON in production C — calls `../json-gate.sh`, the same script `test-all.sh` stage 0 runs |
+| `json-gate` | no hand-written JSON in production C — calls `../json-gate.sh`, the same script `test-all.sh` stage 0 runs. Two rules over runs of concatenated string literals (`json-scan.py`): a run opening an object onto a quoted key, and a run carrying a JSON key separator together with a printf conversion. Falls back to the old single-line grep without python3 |
 | `ips` | refuses lab/private addresses (`10.x`, `192.168.x`) in touched files — the check CI cannot do for you |
 | `trailers` | refuses Signed-off-by / Co-authored-by / review-tag trailer lines, in the message at commit and across the range at push |
 
@@ -51,3 +51,8 @@ it always did.
   people learn to `--no-verify` by reflex.
 - `json-gate.sh` is the single source for the JSON rule; the suite
   and the hooks both call it. Never fork the pattern.
+- The JSON rule carries its own cases: `json-scan.py --selftest`, run
+  by `--tree` before it scans anything. It exists because the rule
+  under-matched for three weeks and only a tree-wide run ever noticed.
+  Add a case with every widening, and one for every near miss that
+  must stay silent.

--- a/tools/conformity/json-gate.sh
+++ b/tools/conformity/json-gate.sh
@@ -4,10 +4,33 @@
 # Structured formats are built by serializers, never string assembly:
 # a "%s" into a JSON literal is one edit away from injection, and the
 # safety of today's literal requires provenance reasoning no reviewer
-# should have to repeat. Two documented exemptions: raptorctl_help.c
-# prints example -j syntax (display text, not construction), and
-# raptor-ipc's transport error frame in rss_ctrl.c (a dependency-free
-# layer emitting a constant shape with one integer).
+# should have to repeat.
+#
+# THE RULE IS TWO RULES, and json-scan.py beside this file implements
+# both over runs of concatenated string literals rather than over
+# lines:
+#
+#   hand-written JSON       a run opening an object onto a quoted key.
+#                           The convention: documents come from cJSON,
+#                           constant ones included, because it is the
+#                           next edit that adds the "%s".
+#   interpolated into JSON  a run carrying a JSON key separator and a
+#                           printf conversion. This is the one with
+#                           teeth -- a document assembled around a
+#                           value at runtime, whatever the braces look
+#                           like.
+#
+# The line grep this replaced matched `{\"` on a single line, which is
+# the idiomatic spelling and nothing else: a space after the brace, a
+# newline, the brace in a macro or the brace as an argument all went
+# through it, and so did any run whose conversion sat on a later line
+# than its brace. C glues adjacent literals together, so the run is the
+# unit that matters.
+#
+# Two documented exemptions: raptorctl_help.c prints example -j syntax
+# (display text, not construction), and raptor-ipc's transport error
+# frame in rss_ctrl.c (a dependency-free layer emitting a constant
+# shape with one integer).
 #
 # Single source of truth: test-all.sh stage 0 and the conformity git
 # hooks both call this script, so the rule cannot drift between them.
@@ -23,26 +46,57 @@ MODE=${1:---tree}
 shift || true
 [ $# -ge 1 ] || exit 0
 
-EXEMPT='raptorctl_help\.c|rss_ctrl\.c'
+# EXEMPT_FILES excuses a whole file, and both modes below apply it, so
+# the hooks and the suite agree about what passes -- a file filter that
+# ran in only one mode used to let a construct through on --tree and
+# flag it on --files.
+EXEMPT_FILES='raptorctl_help\.c|rss_ctrl\.c'
 EXCLUDE_DIRS='/tests/|/fuzz/|/\.deps/|/build/|/asan-out/|/third_party/'
+
+SCAN="$(dirname "$0")/json-scan.py"
 
 case "$MODE" in
 --tree)
-    HITS=$(/usr/bin/grep -rn '{\\"' --include='*.c' --include='*.h' "$@" 2>/dev/null |
-        grep -vE "$EXCLUDE_DIRS" | grep -vE "$EXEMPT" || true)
+    FILES=$(find "$@" -type f \( -name '*.c' -o -name '*.h' \) 2> /dev/null |
+        grep -vE "$EXCLUDE_DIRS" | grep -vE "$EXEMPT_FILES" || true)
     ;;
 --files)
     FILES=$(printf '%s\n' "$@" | grep -E '\.(c|h)$' |
-        grep -vE "$EXCLUDE_DIRS" | grep -vE "^(tests|fuzz)/" | grep -vE "$EXEMPT" || true)
-    [ -n "$FILES" ] || exit 0
-    # shellcheck disable=SC2086
-    HITS=$(/usr/bin/grep -n '{\\"' $FILES 2>/dev/null || true)
+        grep -vE "$EXCLUDE_DIRS" | grep -vE "^(tests|fuzz)/" | grep -vE "$EXEMPT_FILES" || true)
     ;;
 *)
     echo "json-gate: unknown mode $MODE" >&2
     exit 2
     ;;
 esac
+
+[ -n "$FILES" ] || exit 0
+
+# The suite exercises the rule itself before applying it. A gate that
+# quietly stops matching is worse than no gate -- this one did exactly
+# that for three weeks -- and the cases are cheap. Not in --files mode:
+# the hooks are meant to be instant.
+if [ "$MODE" = --tree ] && command -v python3 > /dev/null 2>&1 && [ -f "$SCAN" ]; then
+    if ! OUT=$(python3 "$SCAN" --selftest); then
+        printf '%s\n' "$OUT" >&2
+        echo "json-gate: the rule's own cases fail; fix json-scan.py before trusting it" >&2
+        exit 1
+    fi
+fi
+
+# Fails open the way every conformity check does -- but open here means
+# the old single-line rule, not nothing: a machine without python3 still
+# refuses the spelling that actually occurs.
+if command -v python3 > /dev/null 2>&1 && [ -f "$SCAN" ]; then
+    # shellcheck disable=SC2086
+    # The first argument is a regex excusing one construct wherever it
+    # appears, for a shape no serializer can produce. Nothing needs it yet.
+    HITS=$(python3 "$SCAN" '' $FILES || true)
+else
+    echo "json-gate: python3 not found; falling back to the single-line rule" >&2
+    # shellcheck disable=SC2086
+    HITS=$(/usr/bin/grep -n '{\\"' $FILES 2> /dev/null || true)
+fi
 
 if [ -n "$HITS" ]; then
     echo "$HITS"

--- a/tools/conformity/json-scan.py
+++ b/tools/conformity/json-scan.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""json-scan: find hand-written JSON in C, across concatenated literals.
+
+The rule this implements is json-gate.sh's; this is the half that a
+line-oriented grep could not do.
+
+WHY NOT GREP. The old gate matched the two characters `{\\"` on one
+line, which is the idiomatic spelling and nothing else. All four of
+these are the same defect and all four sailed past it:
+
+    snprintf(b, n, "{ \\"host\\": \\"%s\\" }", host);      a space
+    snprintf(b, n, "{\\n  \\"host\\": \\"%s\\"\\n}", host);  a newline
+    snprintf(b, n, OBJ_OPEN "\\"host\\":\\"%s\\"}", host);  brace in a macro
+    snprintf(b, n, "%s\\"host\\":\\"%s\\"}", "{", host);    brace as an argument
+
+C concatenates adjacent string literals, so the unit that matters is
+the RUN -- every literal the compiler will glue together, including
+across newlines and across a macro name sitting between two of them.
+That is what this scans, which is why the brace can be anywhere in it.
+
+TWO RULES, and they answer different questions.
+
+  shape   a run containing `{"` (escaped) is a JSON object written out
+          by hand. Constant or not, it is the convention: JSON comes
+          from a serializer. This is the old gate's rule, widened to
+          allow whitespace after the brace and to see across a run.
+
+  inject  a run containing a JSON key separator -- a quoted key, a
+          colon, and something a value can start with -- together with
+          a printf conversion. This is the one with teeth: a document
+          assembled around a value at runtime, whatever the braces
+          look like.
+
+`inject` is deliberately not "any \\" plus any %". rhd's
+WWW-Authenticate header carries an escaped quote and a %d in the same
+snprintf and is not JSON, so the key separator is required; and a log
+line reading `\\"%s\\": the standard form is a bare number` is a quoted
+name followed by English, so a JSON value start is required after the
+colon. Both shapes are in the tree and neither is a document.
+
+WHAT IT STILL WILL NOT SEE: a fragment with no key separator of its
+own, assembled into a document somewhere else -- `"\\"host\\",", h` and
+then a brace added later. Catching that needs dataflow, not a scanner,
+and CI is not where that belongs.
+
+Exit 1 and print `file:line: text` (grep -n's shape, so the callers do
+not care which half found it) when anything matches; silent 0 when not.
+"""
+
+import re
+import sys
+
+# A printf conversion, not a literal %%. Flags, width, precision and
+# length modifiers are all optional; the conversion character is what
+# makes it one.
+CONV = re.compile(r"%[-+ #0']*[0-9*]*(?:\.[0-9*]+)?(?:hh|h|ll|l|L|q|j|z|t)?[diouxXeEfFgGaAcspn]")
+
+# A JSON key/value separator: an escaped quote closing a key, a colon,
+# and then something a JSON value can actually start with -- another
+# string, an object, an array, a number, a keyword, or a conversion
+# standing in for one.
+#
+# The value start is what keeps prose out. A log line reads
+#
+#     RSS_WARN("gpio.%s \\"%s\\": the standard form is a bare number")
+#
+# which is a quoted name followed by a colon followed by English, and
+# is not a document. Two of those live in the tree today.
+KEY_SEP = re.compile(r'\\"\s*:\s*(?:\\"|[\[{0-9%-]|true|false|null)')
+
+# An object opening onto a quoted key.
+OBJ_OPEN = re.compile(r'\{\s*\\"')
+
+IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def literal_runs(text):
+    """Yield (line, raw) for each run of adjacent string literals.
+
+    `raw` is the source spelling of the contents with the quotes
+    removed and the parts concatenated -- so a backslash-quote stays a
+    backslash and a quote, which is what both rules look for.
+
+    A run survives whitespace, comments and a bare identifier between
+    two literals, because a macro that expands to a literal is glued in
+    by the compiler like any other part. Any other token ends it.
+    """
+    i, n, line = 0, len(text), 1
+    parts, start = [], 0
+
+    def flush():
+        nonlocal parts, start
+        if parts:
+            yielded = (start, "".join(parts))
+            parts = []
+            return yielded
+        return None
+
+    while i < n:
+        c = text[i]
+
+        if c == "\n":
+            line += 1
+            i += 1
+            continue
+
+        if c.isspace():
+            i += 1
+            continue
+
+        # A macro's line continuation is whitespace to the compiler, so
+        # a document split across the lines of a #define is still one
+        # run. Without this the brace and the conversion can land in
+        # different runs and neither half looks like a document.
+        if c == "\\" and i + 1 < n and text[i + 1] == "\n":
+            line += 1
+            i += 2
+            continue
+
+        if text.startswith("//", i):
+            j = text.find("\n", i)
+            i = n if j < 0 else j
+            continue
+
+        if text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            line += text.count("\n", i, j)
+            i = j
+            continue
+
+        if c == "'":  # a character literal, never a run
+            i += 1
+            while i < n and text[i] != "'":
+                i += 2 if text[i] == "\\" else 1
+            i += 1
+            continue
+
+        if c == '"':
+            if not parts:
+                start = line
+            i += 1
+            begin = i
+            while i < n and text[i] != '"':
+                if text[i] == "\\":
+                    i += 2
+                else:
+                    i += 1
+            parts.append(text[begin:i])
+            line += text.count("\n", begin, i)
+            i += 1
+            continue
+
+        m = IDENT.match(text, i)
+        if m:
+            # Glue only between literals; an identifier on its own
+            # starts nothing.
+            i = m.end()
+            if not parts:
+                continue
+            continue
+
+        run = flush()
+        if run:
+            yield run
+        i += 1
+
+    run = flush()
+    if run:
+        yield run
+
+
+def scan(path, exempt_line):
+    """Return a list of `path:line: text` findings."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        return []
+
+    lines = text.splitlines()
+    out = []
+    for line, raw in literal_runs(text):
+        shape = OBJ_OPEN.search(raw)
+        inject = KEY_SEP.search(raw) and CONV.search(raw)
+        if not shape and not inject:
+            continue
+        # A run's exemption is any of its lines carrying the construct:
+        # a run is often several lines long and the marker sits on the
+        # first of them, so match anywhere in the run, not on line one.
+        window = lines[line - 1 : line + 4]
+        if exempt_line and any(exempt_line.search(x) for x in window):
+            continue
+        why = "interpolated into JSON" if inject else "hand-written JSON"
+        src = lines[line - 1].strip() if line - 1 < len(lines) else ""
+        out.append("%s:%d: %s [%s]" % (path, line, src, why))
+    return out
+
+
+# Both rules by example, and the near misses that must stay quiet. The
+# gate under-matched for three weeks without anyone noticing, so it
+# carries its own cases: `json-scan.py --selftest`.
+SELFTEST = [
+    (True, r'snprintf(b, n, "{\"host\":\"%s\"}", h);', "the idiomatic spelling"),
+    (True, r'snprintf(b, n, "{ \"host\": \"%s\" }", h);', "a space after the brace"),
+    (True, r'snprintf(b, n, "{\n \"host\": \"%s\"\n}", h);', "a newline after it"),
+    (True, r'snprintf(b, n, OPEN "\"host\":\"%s\"}", h);', "the brace in a macro"),
+    (True, r'snprintf(b, n, "%s\"host\":\"%s\"}", "{", h);', "the brace as an argument"),
+    (True, 'snprintf(b, n, "{\\"a\\":1,"\n               "\\"h\\":\\"%s\\"}", h);',
+     "the conversion on a later line than the brace"),
+    (True, r'static const char body[] = "{\"status\":\"error\"}";', "a constant document"),
+    (False, r'snprintf(b, n, "realm=\"raptor\"\r\nLength: %d\r\n", len);',
+     "an HTTP header quotes and counts, and is not JSON"),
+    (False, r'RSS_WARN("gpio.%s \"%s\": the standard form is a number", k, v);',
+     "a quoted name, a colon, then English"),
+    (False, r'snprintf(b, n, "he said \"%s\" loudly", s);', "a quoted value, no key"),
+    (False, r'return "a constant with \"quotes\" and no colon";', "quotes alone"),
+    (False, r'#include "rhd.h"', "an include"),
+    (False, r'const char *u = "http://example/*not a comment*/";',
+     "a comment opener inside a string"),
+    (False, "/* a comment mentioning {\\\"json\\\":\\\"%s\\\"} */ int x;",
+     "a comment describing the thing it forbids"),
+]
+
+# The lexer traps, which need more than one line each.
+SELFTEST_MULTILINE = [
+    (True, '#define T(k) \\\n\t"{\\"cmd\\":\\"" k "\\","\\\n\t"\\"v\\":\\"%s\\"}"',
+     "a document split across a macro's continuation lines"),
+]
+
+
+def selftest():
+    import tempfile, os
+
+    bad = 0
+    cases = [(w, "void f(void)\n{\n\t" + src + "\n}\n", why) for w, src, why in SELFTEST]
+    cases += [(w, src + "\n", why) for w, src, why in SELFTEST_MULTILINE]
+    for want, body, why in cases:
+        fd, path = tempfile.mkstemp(suffix=".c")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(body)
+        got = bool(scan(path, None))
+        os.unlink(path)
+        if got != want:
+            bad += 1
+            print("FAIL  expected %s: %s" % ("a hit" if want else "silence", why))
+            print("      %s" % body.replace("\n", "\\n"))
+    print("json-scan selftest: %d cases, %d failed" % (len(cases), bad))
+    return 1 if bad else 0
+
+
+def main(argv):
+    if len(argv) > 1 and argv[1] == "--selftest":
+        return selftest()
+    exempt = re.compile(argv[1]) if argv[1] else None
+    hits = []
+    for path in argv[2:]:
+        hits += scan(path, exempt)
+    for h in hits:
+        print(h)
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
**This one changes what the next patch can add, not what is in the tree today.**
`main` passes the widened rule as it stands — 114 production sources, no hits.
Worth saying up front so it is reviewed as a gate change rather than a bug fix.

The gate matched the two characters `{\"` on one line, which is the idiomatic
spelling and nothing else. All four of these are the same defect and all four
went straight through it:

```c
snprintf(b, n, "{ \"host\": \"%s\" }", host);      a space
snprintf(b, n, "{\n  \"host\": \"%s\"\n}", host);  a newline
snprintf(b, n, OBJ_OPEN "\"host\":\"%s\"}", host); brace in a macro
snprintf(b, n, "%s\"host\":\"%s\"}", "{", host);   brace as an argument
```

C concatenates adjacent string literals, so the unit the rule has to read is the
**run** — every literal the compiler will glue together, across newlines and
across a macro name sitting between two of them. `json-scan.py` beside the gate
scans runs, which is why the brace can be anywhere in one.

Two rules now, answering different questions:

- **`shape`** — the old rule widened: a run opening an object onto a quoted key,
  constant or not, because it is the next edit that adds the `"%s"`.
- **`inject`** — the one with teeth: a run carrying a JSON key separator *and* a
  printf conversion. A document assembled around a value at runtime, whatever the
  braces look like.

`inject` is deliberately not "any `\"` plus any `%`". rhd's `WWW-Authenticate`
header carries an escaped quote and a `%d` in the same `snprintf` and is not
JSON, so a key separator is required; a log line reading
`\"%s\": the standard form is a bare number` is a quoted name followed by
English, so a JSON value start is required after the colon. Both shapes are in
the tree and neither is a document. Lexing rather than grepping also keeps it
quiet on a brace inside a comment or a character literal.

The gate carries its own cases and runs them before it scans, in `--tree` mode
only so the hooks stay instant: fifteen, each rule by example and every near miss
that has to stay silent. A gate that quietly stops matching is worse than no
gate, and this one did exactly that. Without python3 it falls back to the old
single-line grep — failing open here means the previous rule, not nothing.

Verified by planting each of the four spellings above (all caught) and by a
tree-wide run over every production source (clean).

Cut from `main`, one commit, three files under `tools/conformity`. Host test
suite: 342 pass, 0 fail.

https://claude.ai/code/session_0135iarzELmev2nXzBx4SFLU