### PR TITLE
rod: optional background box behind OSD text elements

### DIFF
--- a/config/raptor.conf
+++ b/config/raptor.conf
@@ -280,6 +280,9 @@ sign_snapshots = false        # Ed25519-sign /snap.jpg (verify: rverify; key: [r
 # font_color = 0xFFFFFFFF       # global default text color (BGRA)
 # font_stroke = 1               # global default stroke width (0-5)
 # stroke_color = 0xFF000000     # global default stroke color (BGRA)
+# background_color = 0x00000000 # global default background box behind text
+#                               # (BGRA; 0 = off; e.g. 0x6E000000 ~43% black,
+#                               # matching prudynt's osd.burnin.background_color)
 # time_format = %Y-%m-%d %H:%M:%S
 # privacy_color = 0xFF000000
 
@@ -303,6 +306,8 @@ sign_snapshots = false        # Ed25519-sign /snap.jpg (verify: rverify; key: [r
 #   color      = 0xFFFFFFFF            (0 = use global, BGRA)
 #   stroke_color = 0xFF000000          (0 = use global, BGRA)
 #   stroke_size = -1                   (-1 = use global)
+#   bg_color = 0x00000000              (0 = use global, BGRA; alpha-respecting
+#                                       box drawn behind the text extent)
 #
 # Image element keys:
 #   path       = /path/to/file.bgra

--- a/raptorctl/raptorctl_dispatch.c
+++ b/raptorctl/raptorctl_dispatch.c
@@ -233,6 +233,7 @@ static const struct cmd_def cmd_table[] = {
 	{"osd-restart", NULL, 0, args_pool_kb},
 	{"set-font-color", NULL, 1, args_val_str},
 	{"set-stroke-color", NULL, 1, args_val_str},
+	{"set-bg-color", NULL, 1, args_val_str},
 	{"set-font-size", NULL, 1, args_val},
 	{"set-stroke-size", NULL, 1, args_val},
 	{"set-time-format", NULL, 1, args_val_str},

--- a/raptorctl/raptorctl_help.c
+++ b/raptorctl/raptorctl_help.c
@@ -136,6 +136,7 @@ const struct help_entry help_entries[] = {
 	{"rod", "set-font-size <10-72>               Global font size"},
 	{"rod", "set-font-color <0xAARRGGBB>         Global text color"},
 	{"rod", "set-stroke-color <0xAARRGGBB>       Global stroke color"},
+	{"rod", "set-bg-color <0xAARRGGBB>           Global text background box (0 = off)"},
 	{"rod", "set-stroke-size <0-5>               Global stroke width"},
 	{"ric", "mode <auto|day|night>               Set day/night mode (GPIO + ISP)"},
 	{"ric", "isp-mode <day|night>                Set ISP mode only (no GPIO)"},

--- a/rod/rod.h
+++ b/rod/rod.h
@@ -83,9 +83,11 @@ typedef struct {
 	int font_size;
 	uint32_t color;
 	uint32_t stroke_color;
+	uint32_t bg_color;
 	int stroke_size;
 	bool has_color;
 	bool has_stroke_color;
+	bool has_bg_color;
 	int align;
 	char position[32];
 	int max_chars;
@@ -136,6 +138,7 @@ typedef struct {
 	int font_size;
 	uint32_t font_color;
 	uint32_t stroke_color;
+	uint32_t bg_color;
 	int font_stroke;
 	char time_format[64];
 	int frame_rate;
@@ -179,10 +182,12 @@ void rod_render_deinit(rod_state_t *st, int stream_idx, int font_idx);
 rod_glyph_t *rod_glyph_lookup(rod_font_t *font, uint32_t codepoint);
 void rod_draw_text(rod_state_t *st, int stream_idx, int font_idx, uint8_t *buf, uint32_t buf_w,
 		   uint32_t buf_h, const char *text, int align, uint32_t color,
-		   uint32_t stroke_color, int stroke_size);
+		   uint32_t stroke_color, int stroke_size, uint32_t bg_color);
 int rod_load_logo(const char *path, int expected_w, int expected_h, uint8_t **out_data);
 void rod_draw_rect_outline(uint8_t *buf, uint32_t buf_w, uint32_t buf_h, int x0, int y0, int x1,
 			   int y1, uint32_t color_bgra, int thickness);
+void rod_draw_rect_fill(uint8_t *buf, uint32_t buf_w, uint32_t buf_h, int x0, int y0, int x1,
+			int y1, uint32_t color_bgra);
 
 /* rod_receipt.c -- receipt element */
 void rod_receipt_add_line(rod_element_t *e, const char *line);

--- a/rod/rod_config.c
+++ b/rod/rod_config.c
@@ -35,6 +35,7 @@ void load_config(rod_state_t *st)
 	c->font_size = rss_config_get_int(cfg, "osd", "font_size", 24);
 	c->font_color = parse_color(rss_config_get_str(cfg, "osd", "font_color", "0xFFFFFFFF"));
 	c->stroke_color = parse_color(rss_config_get_str(cfg, "osd", "stroke_color", "0xFF000000"));
+	c->bg_color = parse_color(rss_config_get_str(cfg, "osd", "background_color", "0x00000000"));
 	c->font_stroke = rss_config_get_int(cfg, "osd", "font_stroke", 1);
 	rss_strlcpy(c->time_format,
 		    rss_config_get_str(cfg, "osd", "time_format", "%Y-%m-%d %H:%M:%S"),
@@ -195,6 +196,12 @@ static void load_osd_section(const char *section, void *userdata)
 	if (sc_str) {
 		e->stroke_color = (uint32_t)strtoul(sc_str, NULL, 0);
 		e->has_stroke_color = true;
+	}
+
+	const char *bg_str = rss_config_get_str(cfg, section, "bg_color", NULL);
+	if (bg_str) {
+		e->bg_color = (uint32_t)strtoul(bg_str, NULL, 0);
+		e->has_bg_color = true;
 	}
 
 	ctx->count++;

--- a/rod/rod_ctrl.c
+++ b/rod/rod_ctrl.c
@@ -327,6 +327,12 @@ static int handle_set_element(rod_state_t *st, const char *cmd_json, char *resp,
 		mark_element_dirty(e, st->stream_count);
 	}
 
+	if (rss_json_get_str(cmd_json, "bg_color", val, sizeof(val)) == 0) {
+		e->bg_color = (uint32_t)strtoul(val, NULL, 0);
+		e->has_bg_color = true;
+		mark_element_dirty(e, st->stream_count);
+	}
+
 	if (rss_json_get_int(cmd_json, "stroke_size", &ival) == 0 && ival >= 0 && ival <= 5) {
 		e->stroke_size = ival;
 		mark_element_dirty(e, st->stream_count);
@@ -486,6 +492,10 @@ int rod_ctrl_handler(const char *cmd_json, char *resp_buf, int resp_buf_size, vo
 	if (strcmp(cmd, "set-font-color") == 0)
 		return handle_color_change(st, cmd_json, resp_buf, resp_buf_size, "font_color",
 					   &st->settings.font_color);
+
+	if (strcmp(cmd, "set-bg-color") == 0)
+		return handle_color_change(st, cmd_json, resp_buf, resp_buf_size,
+					   "background_color", &st->settings.bg_color);
 
 	if (strcmp(cmd, "set-stroke-color") == 0)
 		return handle_color_change(st, cmd_json, resp_buf, resp_buf_size, "stroke_color",

--- a/rod/rod_main.c
+++ b/rod/rod_main.c
@@ -36,9 +36,10 @@ static void render_text_element(rod_state_t *st, rod_element_t *e, int s, const 
 	uint32_t col = e->has_color ? e->color : st->settings.font_color;
 	uint32_t scol = e->has_stroke_color ? e->stroke_color : st->settings.stroke_color;
 	int ssz = e->stroke_size >= 0 ? e->stroke_size : st->settings.font_stroke;
+	uint32_t bg = e->has_bg_color ? e->bg_color : st->settings.bg_color;
 
 	rod_draw_text(st, s, es->font_idx, buf, es->width, es->height, text, e->align, col, scol,
-		      ssz);
+		      ssz, bg);
 	rss_osd_publish(es->shm);
 }
 

--- a/rod/rod_receipt.c
+++ b/rod/rod_receipt.c
@@ -113,19 +113,12 @@ void rod_render_receipt(rod_state_t *st, rod_element_t *e, int s)
 		line_h = 16;
 
 	uint32_t bg = e->receipt.bg_color;
-	if (bg) {
-		uint32_t fill_h = (uint32_t)(e->receipt.count * line_h);
-		if (fill_h > bh)
-			fill_h = bh;
-		uint8_t *p = buf;
-		for (uint32_t i = 0; i < bw * fill_h; i++) {
-			p[0] = (uint8_t)(bg & 0xFF);
-			p[1] = (uint8_t)((bg >> 8) & 0xFF);
-			p[2] = (uint8_t)((bg >> 16) & 0xFF);
-			p[3] = (uint8_t)((bg >> 24) & 0xFF);
-			p += 4;
-		}
-	}
+	if (bg)
+		rod_draw_rect_fill(buf, bw, bh, 0, 0, (int)bw - 1,
+				   (int)(e->receipt.count * line_h) > (int)bh
+					   ? (int)bh - 1
+					   : (int)(e->receipt.count * line_h) - 1,
+				   bg);
 
 	/* Draw lines from oldest to newest */
 	int start = (e->receipt.head - e->receipt.count + ROD_RECEIPT_MAX_LINES) %
@@ -146,7 +139,7 @@ void rod_render_receipt(rod_state_t *st, rod_element_t *e, int s)
 			row_h = (int)bh - y_offset;
 
 		rod_draw_text(st, s, es->font_idx, row_buf, bw, row_h, line, e->align, col, scol,
-			      ssz);
+			      ssz, 0);
 
 		y_offset += line_h;
 	}

--- a/rod/rod_render.c
+++ b/rod/rod_render.c
@@ -174,6 +174,58 @@ static void blit_glyph(uint8_t *buf, uint32_t buf_w, uint32_t buf_h, const rod_g
 }
 
 /*
+ * Alpha-blend a solid-color rectangle into a BGRA buffer (source-over).
+ */
+static void blit_rect(uint8_t *buf, uint32_t buf_w, uint32_t buf_h, int x0, int y0, int x1, int y1,
+		      uint8_t b, uint8_t g, uint8_t r, uint8_t a)
+{
+	if (x0 < 0)
+		x0 = 0;
+	if (y0 < 0)
+		y0 = 0;
+	if (x1 >= (int)buf_w)
+		x1 = (int)buf_w - 1;
+	if (y1 >= (int)buf_h)
+		y1 = (int)buf_h - 1;
+	for (int y = y0; y <= y1; y++) {
+		for (int x = x0; x <= x1; x++) {
+			uint8_t *dst = buf + (y * buf_w + x) * 4;
+			uint8_t inv = 255 - a;
+			dst[0] = (uint8_t)((b * a + dst[0] * inv) / 255);
+			dst[1] = (uint8_t)((g * a + dst[1] * inv) / 255);
+			dst[2] = (uint8_t)((r * a + dst[2] * inv) / 255);
+			dst[3] = (uint8_t)(a + (dst[3] * inv) / 255);
+		}
+	}
+}
+
+/*
+ * Fill a rectangle in a BGRA buffer with an opaque copy of color.
+ */
+void rod_draw_rect_fill(uint8_t *buf, uint32_t buf_w, uint32_t buf_h, int x0, int y0, int x1,
+			int y1, uint32_t color_bgra)
+{
+	uint8_t b = (uint8_t)(color_bgra & 0xFF);
+	uint8_t g = (uint8_t)((color_bgra >> 8) & 0xFF);
+	uint8_t r = (uint8_t)((color_bgra >> 16) & 0xFF);
+	uint8_t a = (uint8_t)((color_bgra >> 24) & 0xFF);
+
+	for (int y = y0; y <= y1; y++) {
+		if (y < 0 || y >= (int)buf_h)
+			continue;
+		for (int x = x0; x <= x1; x++) {
+			if (x < 0 || x >= (int)buf_w)
+				continue;
+			uint8_t *dst = buf + (y * buf_w + x) * 4;
+			dst[0] = b;
+			dst[1] = g;
+			dst[2] = r;
+			dst[3] = a;
+		}
+	}
+}
+
+/*
  * Draw a text string at pen position, advancing per glyph.
  * Returns final pen_x (for measuring).
  */
@@ -210,7 +262,7 @@ static int measure_text(rod_font_t *f, const char *text)
 
 void rod_draw_text(rod_state_t *st, int stream_idx, int font_idx, uint8_t *buf, uint32_t buf_w,
 		   uint32_t buf_h, const char *text, int align, uint32_t color,
-		   uint32_t stroke_color, int stroke_size)
+		   uint32_t stroke_color, int stroke_size, uint32_t bg_color)
 {
 	rod_font_t *f = &st->fonts[stream_idx][font_idx];
 	int stroke = stroke_size;
@@ -235,6 +287,21 @@ void rod_draw_text(rod_state_t *st, int stream_idx, int font_idx, uint8_t *buf, 
 
 	if (pen_x < pad)
 		pen_x = pad;
+
+	/* Semi-transparent background box behind the text (prudynt-style).
+	 * Drawn before stroke/text so glyphs blend on top of it. */
+	if (bg_color != 0 && text_w > 0) {
+		uint8_t bg_a = (uint8_t)((bg_color >> 24) & 0xFF);
+		if (bg_a != 0) {
+			int box_x0 = pen_x - pad;
+			int box_x1 = pen_x + text_w + pad;
+			int box_y0 = 0;
+			int box_y1 = (int)buf_h - 1;
+			blit_rect(buf, buf_w, buf_h, box_x0, box_y0, box_x1, box_y1,
+				  (uint8_t)(bg_color & 0xFF), (uint8_t)((bg_color >> 8) & 0xFF),
+				  (uint8_t)((bg_color >> 16) & 0xFF), bg_a);
+		}
+	}
 
 	if (stroke > 0) {
 		uint8_t s_b = (uint8_t)(stroke_color & 0xFF);


### PR DESCRIPTION
## What

Adds an optional semi-transparent background rectangle drawn behind ROD **text** OSD elements - the prudynt/ciao-style text box, so text stays readable against bright skies, snow and walls.

## Why

Prudynt burns its OSD text over a background box (`osd.burnin.background_color`, shipped default `#00000080`). Raptor ROD text elements so far only support `color` / `stroke_color` / `stroke_size`, so text is composited straight over video and washes out on bright scenes. This adds the missing fill at the renderer level.

## How

- `rod_draw_text()` gains a `bg_color` parameter. When non-zero (alpha set), it alpha-blends a rectangle over the measured text extent (plus stroke padding) *before* stroke/text rendering, so glyphs composite on top through the existing blit paths.
- Global default `[osd] background_color = 0x00000000` (off) - zero behavior change for existing configs.
- Per-element override: `bg_color` in `[osd.<name>]` sections, and via the control socket (`add-element` / element updates).
- New global command `raptorctl rod set-bg-color <0xAARRGGBB>`, following the existing `set-font-color` / `set-stroke-color` pattern.
- The receipt element keeps its own `bg_color` fill; its per-pixel loop is now the shared `rod_draw_rect_fill` helper.

Example - prudynt-like look:

```
[osd]
background_color = 0x80000000   # ~50% black box behind every text element

[osd.camera]
template = %hostname%
bg_color = 0x6E000000           # per-element override, ~43% black
```

## Testing

- Host compile check: `gcc -fsyntax-only -Wall -Wextra -Werror` clean across all `rod/*.c` and the touched raptorctl sources. No device run yet.
- Existing configs: default 0 = no box, no visual change.

## Notes for reviewers

- The box spans the full element-buffer height (vertical padding comes from buffer sizing) and hugs the measured text width - the same tight box prudynt draws, not a full-width bar.
- Colors are `0xAARRGGBB` parsed as BGRA, matching the existing color keys.


---

**Related Discord discussion:** https://discord.com/channels/1086012062649565286/1546872167239520337